### PR TITLE
Add class hash

### DIFF
--- a/crates/trace-data/src/lib.rs
+++ b/crates/trace-data/src/lib.rs
@@ -124,6 +124,7 @@ pub enum DeprecatedSyscallSelector {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CallEntryPoint {
+    pub class_hash: Option<ClassHash>,
     pub entry_point_type: EntryPointType,
     pub entry_point_selector: EntryPointSelector,
     pub contract_address: ContractAddress,


### PR DESCRIPTION
Removed before, but now needed for recognising which sierra (from which contract) should I use for generating function level trace in calls. Not sure if this should be an `Option` but it seems safer (e.g. in the future we may want to support profiling failed calls among which e.g. calling uninitialized storage (so no class hash there) can happen, someone may have no access to class hash info etc.).