### PR TITLE
`--max-function-trace-depth` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - basic function level profiling
+- `--max-function-trace-depth` allowing to specify maximum depth of the function tree in function level profiling
 
 ## [0.3.0-dev.0] - 2024-04-17
 

--- a/crates/cairo-profiler/src/main.rs
+++ b/crates/cairo-profiler/src/main.rs
@@ -32,6 +32,13 @@ struct Cli {
     /// Show contract addresses and function selectors in a trace tree
     #[arg(long)]
     show_details: bool,
+
+    /// Specify maximum depth of function tree in function level profiling.
+    /// The is applied per entrypoint - each entrypoint function tree is treated separately.
+    /// Keep in mind recursive functions are also taken into account even though they are later
+    /// aggregated to one function call.
+    #[arg(long, default_value_t = 100)]
+    max_function_trace_depth: usize,
 }
 
 fn main() -> Result<()> {
@@ -47,6 +54,7 @@ fn main() -> Result<()> {
         &serialized_trace,
         &compiled_artifacts_path_map,
         cli.show_details,
+        cli.max_function_trace_depth,
     )?;
 
     let profile = build_profile(&samples);

--- a/crates/cairo-profiler/src/trace_reader.rs
+++ b/crates/cairo-profiler/src/trace_reader.rs
@@ -156,6 +156,7 @@ pub fn collect_samples_from_trace(
     trace: &CallTrace,
     compiled_artifacts_path_map: &CompiledArtifactsPathMap,
     show_details: bool,
+    max_function_trace_depth: usize,
 ) -> Result<Vec<ContractCallSample>> {
     let mut samples = vec![];
     let mut current_path = vec![];
@@ -166,6 +167,7 @@ pub fn collect_samples_from_trace(
         trace,
         compiled_artifacts_path_map,
         show_details,
+        max_function_trace_depth,
     )?;
     Ok(samples)
 }
@@ -176,6 +178,7 @@ fn collect_samples<'a>(
     trace: &'a CallTrace,
     compiled_artifacts_path_map: &CompiledArtifactsPathMap,
     show_details: bool,
+    max_function_trace_depth: usize,
 ) -> Result<&'a ExecutionResources> {
     current_call_stack.push(EntryPointId::from(
         trace.entry_point.contract_name.clone(),
@@ -204,6 +207,7 @@ fn collect_samples<'a>(
             compiled_artifacts.sierra.get_program_artifact(),
             &compiled_artifacts.casm_debug_info,
             compiled_artifacts.sierra.was_run_with_header(),
+            max_function_trace_depth,
         )?;
 
         for mut function_stack_trace in profiling_info.functions_stack_traces {
@@ -236,6 +240,7 @@ fn collect_samples<'a>(
                 sub_trace,
                 compiled_artifacts_path_map,
                 show_details,
+                max_function_trace_depth,
             )?;
         }
     }

--- a/crates/cairo-profiler/tests/e2e.rs
+++ b/crates/cairo-profiler/tests/e2e.rs
@@ -23,6 +23,7 @@ fn output_path() {
     assert!(temp_dir.join("my/output/dir/my_file.pb.gz").exists());
 }
 
+#[test_case(&["call.json", "--max-function-trace-depth", "5"]; "with max function trace depth")]
 #[test_case(&["call.json", "--show-details"]; "with details")]
 #[test_case(&["call.json"]; "without details")]
 fn simple_package(args: &[&str]) {


### PR DESCRIPTION
Closes https://github.com/foundry-rs/starknet-foundry/issues/2122

Checked on alexandria (5 vs default 100):
<img width="667" alt="image" src="https://github.com/software-mansion/cairo-profiler/assets/56825108/f4bef463-4d5d-4f13-ae7e-24f6f242a514">
<img width="778" alt="image" src="https://github.com/software-mansion/cairo-profiler/assets/56825108/8a60791f-9996-4fea-8074-11909afc002d">

## Introduced changes

- as in the issue description

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation (README.md)
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
