### PR TITLE
`--split-generics` flag 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `--max-function-trace-depth` allowing to specify maximum depth of the function tree in function level profiling
+- `--split-generics` flag allowing to differentiate between non-inlined generics monomorphised with different types
  
 ## [0.3.0] - 2024-04-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - basic function level profiling
+- `--max-function-trace-depth` allowing to specify maximum depth of the function tree in function level profiling
 
 ## [0.3.0-dev.0] - 2024-04-17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,6 +443,7 @@ dependencies = [
  "flate2",
  "hex",
  "itertools 0.11.0",
+ "lazy_static",
  "project-root",
  "prost",
  "prost-build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ test-case = "3.3.1"
 itertools = "0.11.0"
 tempfile = "3.10.1"
 regex = "1.10"
+lazy_static = "1.4.0"
 
 cairo-lang-sierra = { git = "https://github.com/starkware-libs/cairo.git", rev = "852f8fb" }
 cairo-lang-sierra-to-casm = { git = "https://github.com/starkware-libs/cairo.git", rev = "852f8fb" }

--- a/crates/cairo-profiler/Cargo.toml
+++ b/crates/cairo-profiler/Cargo.toml
@@ -19,6 +19,7 @@ anyhow.workspace = true
 itertools.workspace = true
 tempfile.workspace = true
 regex.workspace = true
+lazy_static.workspace = true
 trace-data = { path = "../trace-data" }
 
 cairo-lang-sierra.workspace = true

--- a/crates/cairo-profiler/src/main.rs
+++ b/crates/cairo-profiler/src/main.rs
@@ -32,6 +32,13 @@ struct Cli {
     /// Show contract addresses and function selectors in a trace tree
     #[arg(long)]
     show_details: bool,
+
+    /// Specify maximum depth of function tree in function level profiling.
+    /// The is applied per entrypoint - each entrypoint function tree is treated separately.
+    /// Keep in mind recursive functions are also taken into account even though they are later
+    /// aggregated to one function call.
+    #[arg(long, default_value_t = 100)]
+    max_function_trace_depth: usize,
 }
 
 fn main() -> Result<()> {
@@ -47,6 +54,7 @@ fn main() -> Result<()> {
         &serialized_trace,
         &compiled_artifacts_path_map,
         cli.show_details,
+        cli.max_function_trace_depth,
     )?;
 
     let profile = build_profile(&samples);

--- a/crates/cairo-profiler/src/profile_builder.rs
+++ b/crates/cairo-profiler/src/profile_builder.rs
@@ -10,7 +10,8 @@ use std::collections::{HashMap, HashSet};
 
 pub use perftools::profiles as pprof;
 
-use crate::trace_reader::{ContractCallSample, FunctionName, MeasurementUnit, MeasurementValue};
+use crate::trace_reader::functions::FunctionName;
+use crate::trace_reader::{ContractCallSample, MeasurementUnit, MeasurementValue};
 
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
 pub struct StringId(pub u64);

--- a/crates/cairo-profiler/src/profiler_config.rs
+++ b/crates/cairo-profiler/src/profiler_config.rs
@@ -1,0 +1,31 @@
+use crate::Cli;
+
+pub struct ProfilerConfig {
+    pub show_details: bool,
+    pub max_function_trace_depth: usize,
+    pub split_generics: bool,
+}
+
+impl ProfilerConfig {
+    pub fn from_cli(cli: &Cli) -> ProfilerConfig {
+        ProfilerConfig {
+            show_details: cli.show_details,
+            max_function_trace_depth: cli.max_function_trace_depth,
+            split_generics: cli.split_generics,
+        }
+    }
+}
+
+pub struct FunctionLevelConfig {
+    pub max_function_trace_depth: usize,
+    pub split_generics: bool,
+}
+
+impl FunctionLevelConfig {
+    pub fn from_profiler_config(profiler_config: &ProfilerConfig) -> FunctionLevelConfig {
+        FunctionLevelConfig {
+            max_function_trace_depth: profiler_config.max_function_trace_depth,
+            split_generics: profiler_config.split_generics,
+        }
+    }
+}

--- a/crates/cairo-profiler/src/trace_reader.rs
+++ b/crates/cairo-profiler/src/trace_reader.rs
@@ -156,6 +156,7 @@ pub fn collect_samples_from_trace(
     trace: &CallTrace,
     compiled_artifacts_path_map: &CompiledArtifactsPathMap,
     show_details: bool,
+    max_function_trace_depth: usize,
 ) -> Result<Vec<ContractCallSample>> {
     let mut samples = vec![];
     let mut current_path = vec![];
@@ -166,6 +167,7 @@ pub fn collect_samples_from_trace(
         trace,
         compiled_artifacts_path_map,
         show_details,
+        max_function_trace_depth,
     )?;
     Ok(samples)
 }
@@ -176,6 +178,7 @@ fn collect_samples<'a>(
     trace: &'a CallTrace,
     compiled_artifacts_path_map: &CompiledArtifactsPathMap,
     show_details: bool,
+    max_function_trace_depth: usize,
 ) -> Result<&'a ExecutionResources> {
     current_call_stack.push(EntryPointId::from(
         trace.entry_point.contract_name.clone(),
@@ -204,6 +207,7 @@ fn collect_samples<'a>(
             compiled_artifacts.sierra.get_program_artifact(),
             &compiled_artifacts.casm_debug_info,
             compiled_artifacts.sierra.was_run_with_header(),
+            max_function_trace_depth,
         )?;
 
         for mut function_stack_trace in profiling_info.functions_stack_traces {
@@ -236,6 +240,7 @@ fn collect_samples<'a>(
                 sub_trace,
                 compiled_artifacts_path_map,
                 show_details,
+                max_function_trace_depth,
             )?;
         }
     }

--- a/crates/cairo-profiler/src/trace_reader.rs
+++ b/crates/cairo-profiler/src/trace_reader.rs
@@ -1,27 +1,19 @@
 use core::fmt;
-use itertools::Itertools;
 use std::collections::HashMap;
 use std::fmt::Display;
 
 use crate::profiler_config::{FunctionLevelConfig, ProfilerConfig};
 use crate::sierra_loader::CompiledArtifactsPathMap;
 use crate::trace_reader::function_trace_builder::collect_profiling_info;
+use crate::trace_reader::functions::FunctionName;
 use anyhow::{Context, Result};
+use itertools::Itertools;
 use trace_data::{
     CallTrace, CallTraceNode, ContractAddress, EntryPointSelector, ExecutionResources, L1Resources,
 };
 
 mod function_trace_builder;
-
-#[derive(Clone, Hash, Eq, PartialEq)]
-pub struct FunctionName(pub String);
-
-impl FunctionName {
-    #[inline]
-    fn from(entry_point_id: &EntryPointId) -> FunctionName {
-        FunctionName(format!("{entry_point_id}"))
-    }
-}
+pub mod functions;
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub struct MeasurementUnit(pub String);
@@ -206,7 +198,7 @@ fn collect_samples<'a>(
             &compiled_artifacts.casm_debug_info,
             compiled_artifacts.sierra.was_run_with_header(),
             &FunctionLevelConfig::from_profiler_config(profiler_config),
-        )?;
+        );
 
         for mut function_stack_trace in profiling_info.functions_stack_traces {
             let mut function_trace = current_call_stack

--- a/crates/cairo-profiler/src/trace_reader/functions.rs
+++ b/crates/cairo-profiler/src/trace_reader/functions.rs
@@ -1,0 +1,60 @@
+use crate::trace_reader::function_trace_builder::Steps;
+use crate::trace_reader::EntryPointId;
+use itertools::Itertools;
+use lazy_static::lazy_static;
+use regex::Regex;
+
+lazy_static! {
+    static ref RE_LOOP_FUNC: Regex = Regex::new(r"\[expr\d*\]")
+        .expect("Failed to create regex normalising loop functions names");
+    static ref RE_MONOMORPHIZATION: Regex = Regex::new(r"<.*>")
+        .expect("Failed to create regex normalising mononorphised generic functions names");
+}
+
+#[derive(Clone, Hash, Eq, PartialEq)]
+pub struct FunctionName(pub String);
+
+impl From<&EntryPointId> for FunctionName {
+    fn from(value: &EntryPointId) -> Self {
+        FunctionName(format!("{value}"))
+    }
+}
+
+impl FunctionName {
+    pub fn to_displayable_function_name(&self, split_generics: bool) -> FunctionName {
+        // Remove suffix in case of loop function e.g. `[expr36]`.
+        let func_name = RE_LOOP_FUNC.replace(&self.0, "");
+        // Remove parameters from monomorphised Cairo generics e.g. `<felt252>`.
+        FunctionName(
+            if split_generics {
+                func_name
+            } else {
+                RE_MONOMORPHIZATION.replace(&func_name, "")
+            }
+            .to_string(),
+        )
+    }
+}
+
+pub struct FunctionStackTrace {
+    pub stack_trace: Vec<FunctionName>,
+    pub steps: Steps,
+}
+
+impl FunctionStackTrace {
+    pub fn to_displayable_function_stack_trace(&self, split_generics: bool) -> FunctionStackTrace {
+        let stack_with_recursive_functions = self
+            .stack_trace
+            .iter()
+            .map(|function_name| function_name.to_displayable_function_name(split_generics))
+            .collect_vec();
+
+        // Consolidate recursive function calls into one function call - they mess up the flame graph.
+        let displayable_stack_trace = stack_with_recursive_functions.into_iter().dedup().collect();
+
+        FunctionStackTrace {
+            stack_trace: displayable_stack_trace,
+            steps: self.steps,
+        }
+    }
+}

--- a/crates/cairo-profiler/tests/e2e.rs
+++ b/crates/cairo-profiler/tests/e2e.rs
@@ -23,6 +23,7 @@ fn output_path() {
     assert!(temp_dir.join("my/output/dir/my_file.pb.gz").exists());
 }
 
+#[test_case(&["call.json", "--max-function-trace-depth", "5"]; "with max function trace depth")]
 #[test_case(&["call.json", "--show-details"]; "with details")]
 #[test_case(&["call.json"]; "without details")]
 fn simple_package(args: &[&str]) {

--- a/crates/cairo-profiler/tests/e2e.rs
+++ b/crates/cairo-profiler/tests/e2e.rs
@@ -23,6 +23,7 @@ fn output_path() {
     assert!(temp_dir.join("my/output/dir/my_file.pb.gz").exists());
 }
 
+#[test_case(&["call.json", "--split-generics"]; "with split generics")]
 #[test_case(&["call.json", "--max-function-trace-depth", "5"]; "with max function trace depth")]
 #[test_case(&["call.json", "--show-details"]; "with details")]
 #[test_case(&["call.json"]; "without details")]


### PR DESCRIPTION
Closes https://github.com/foundry-rs/starknet-foundry/issues/2131

## Introduced changes

- `--split-generics` flag for differentiating between non-inlined monomorphised generics

## Checklist

- [x] Linked relevant issue
- [ ] Updated relevant documentation (README.md)
- [x] Added relevant tests
- [x] Performed self-review of the code
- [x] Added changes to `CHANGELOG.md`
