### PR TITLE
Update warning message

### DIFF
--- a/crates/cairo-profiler/src/main.rs
+++ b/crates/cairo-profiler/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> Result<()> {
         eprintln!(
             "[\x1b[0;33mWARNING\x1b[0m] Mappings used for generating information about \
         inlined functions are missing. Make sure to add this to your Scarb.toml:\n\
-        [cairo]\nunstable-add-statements-functions-debug-info = true"
+        [profile.dev.cairo]\nunstable-add-statements-functions-debug-info = true"
         );
     }
 


### PR DESCRIPTION
`[cairo]` section overrides it for all profiles (including the release one). It is safe to assume that overriding the `dev` profile is enough since `snforge` uses it to build contracts and tests