### PR TITLE
Fix clippy 1.83.0 warnings

### DIFF
--- a/crates/cairo-profiler/src/main.rs
+++ b/crates/cairo-profiler/src/main.rs
@@ -65,8 +65,9 @@ fn main() -> Result<()> {
 
     let data = fs::read_to_string(&cli.path_to_trace_data)
         .context("Failed to read call trace from a file")?;
-    let os_resources_map = read_and_parse_versioned_constants_file(&cli.versioned_constants_path)
-        .context("Failed to get resource map from versioned constants file")?;
+    let os_resources_map =
+        read_and_parse_versioned_constants_file(cli.versioned_constants_path.as_ref())
+            .context("Failed to get resource map from versioned constants file")?;
     let VersionedCallTrace::V1(serialized_trace) =
         serde_json::from_str(&data).context("Failed to deserialize call trace")?;
 

--- a/crates/cairo-profiler/src/trace_reader.rs
+++ b/crates/cairo-profiler/src/trace_reader.rs
@@ -73,7 +73,7 @@ fn collect_samples<'a>(
             compiled_artifacts.sierra_program.get_program(),
             &compiled_artifacts.casm_debug_info,
             &cairo_execution_info.casm_level_info,
-            &compiled_artifacts.statements_functions_map,
+            compiled_artifacts.statements_functions_map.as_ref(),
             &FunctionLevelConfig::from(profiler_config),
             os_resources_map,
         );

--- a/crates/cairo-profiler/src/trace_reader/function_trace_builder.rs
+++ b/crates/cairo-profiler/src/trace_reader/function_trace_builder.rs
@@ -49,7 +49,7 @@ pub fn collect_function_level_profiling_info(
     program: &Program,
     casm_debug_info: &CairoProgramDebugInfo,
     casm_level_info: &CasmLevelInfo,
-    statements_functions_map: &Option<ProfilerAnnotationsV1>,
+    statements_functions_map: Option<&ProfilerAnnotationsV1>,
     function_level_config: &FunctionLevelConfig,
     os_resources_map: &OsResources,
 ) -> FunctionLevelProfilingInfo {
@@ -103,7 +103,7 @@ pub fn collect_function_level_profiling_info(
             current_function_name,
             function_level_config.show_inlined_functions,
             sierra_statement_idx,
-            statements_functions_map.as_ref(),
+            statements_functions_map,
         );
 
         *functions_stack_traces

--- a/crates/cairo-profiler/src/versioned_constants_reader.rs
+++ b/crates/cairo-profiler/src/versioned_constants_reader.rs
@@ -13,7 +13,7 @@ pub struct OsResources {
 
 /// Reads and parses the resource map file at given path
 /// It also checks that the file have cost information about all required libfuncs (syscalls)
-pub fn read_and_parse_versioned_constants_file(path: &Option<Utf8PathBuf>) -> Result<OsResources> {
+pub fn read_and_parse_versioned_constants_file(path: Option<&Utf8PathBuf>) -> Result<OsResources> {
     let file_content = match path {
         Some(path) => fs::read_to_string(path).with_context(|| {
             format!("Cannot read versioned constants file at specified path {path}")


### PR DESCRIPTION

## Introduced changes

- Fix clippy warnings introduced after new rust version

## Checklist

- [ ] Linked relevant issue
- [ ] Updated relevant documentation (README.md)
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
