### PR TITLE
Include only non-zero l2_l1_message_sizes samples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `l2_l1_message_sizes` sample no longer is displayed when its value is zero
+
 ## [0.7.0] - 2024-11-27
 
 - show syscalls as nodes in trace tree rather than samples

--- a/crates/cairo-profiler/src/trace_reader/sample.rs
+++ b/crates/cairo-profiler/src/trace_reader/sample.rs
@@ -87,11 +87,20 @@ impl Sample {
         assert!(
             !measurements.contains_key(&MeasurementUnit::from("l2_l1_message_sizes".to_string()))
         );
-        let summarized_payload: usize = l1_resources.l2_l1_message_sizes.iter().sum();
-        measurements.insert(
-            MeasurementUnit::from("l2_l1_message_sizes".to_string()),
-            MeasurementValue(i64::try_from(summarized_payload).unwrap()),
-        );
+
+        l1_resources
+            .l2_l1_message_sizes
+            .iter()
+            .sum::<usize>()
+            .try_into()
+            .ok()
+            .filter(|summarized_resources| *summarized_resources > 0)
+            .map(|summarized_resources| {
+                measurements.insert(
+                    MeasurementUnit::from("l2_l1_message_sizes".to_string()),
+                    MeasurementValue(summarized_resources),
+                )
+            });
 
         Sample {
             call_stack,


### PR DESCRIPTION
Closes #83 

## Introduced changes

- fixed displaying a `l2_l1_message_sizes` sample even when it is 0

before (white screen when said sample picked):
<img width="1189" alt="obraz" src="https://github.com/user-attachments/assets/01116dd1-9dfb-4212-86ff-10c3a672751f">

after (when 0):
<img width="727" alt="obraz" src="https://github.com/user-attachments/assets/48bb83c8-fa43-4f0b-8b3c-15e0ed168566">

verified it works as expected when `l2_l1_message_sizes` is non zero

## Checklist

- [ ] Linked relevant issue
- [ ] Updated relevant documentation (README.md)
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
