### PR TITLE
Set new command line interface

### DIFF
--- a/crates/cairo-profiler/src/cli/build_profile.rs
+++ b/crates/cairo-profiler/src/cli/build_profile.rs
@@ -1,0 +1,55 @@
+use camino::Utf8PathBuf;
+use clap::Args;
+
+#[derive(Args, Debug)]
+pub struct BuildProfile {
+    /// Path to .json with trace data
+    pub path_to_trace_data: Utf8PathBuf,
+
+    /// Path to the output file
+    #[arg(short, long, default_value = "profile.pb.gz")]
+    pub output_path: Utf8PathBuf,
+
+    /// Show contract addresses and function selectors in a trace tree
+    #[arg(long)]
+    pub show_details: bool,
+
+    /// Specify maximum depth of function tree in function level profiling.
+    /// The is applied per entrypoint - each entrypoint function tree is treated separately.
+    #[arg(long, default_value_t = 100)]
+    pub max_function_stack_trace_depth: usize,
+
+    /// Split non-inlined generic functions based on the type they were monomorphised with.
+    /// E.g. treat `function<felt252>` as different from `function<u8>`.
+    #[arg(long)]
+    pub split_generics: bool,
+
+    /// Show inlined function in a trace tree. Requires Scarb >= 2.7.0-rc.0 and setting
+    /// `unstable-add-statements-functions-debug-info = true` in `[cairo]` section of Scarb.toml.
+    #[arg(long)]
+    pub show_inlined_functions: bool,
+
+    /// Path to a file, that includes a map with cost of resources like syscalls.
+    /// If not provided, the cost map will default to the one used on Starknet 0.13.3.
+    /// Files for different Starknet versions can be found in the sequencer repo:
+    /// <https://github.com/starkware-libs/sequencer/blob/main/crates/blockifier/resources/>
+    #[arg(long)]
+    pub versioned_constants_path: Option<Utf8PathBuf>,
+
+    /// View the resulting profile.
+    /// To view already-built profile run `cairo-profiler view`.
+    #[arg(long)]
+    pub view: bool,
+
+    /// Show the sample in the top view.
+    /// Requires `--view` flag to be set.
+    /// To view already-built profile run `cairo-profiler view`.
+    #[arg(long, requires = "view", default_value = "steps")]
+    pub sample: String,
+
+    /// Set a limit of viewed nodes.
+    /// Requires `--view` flag to be set.
+    /// To view already-built profile run `cairo-profiler view`.
+    #[arg(long, requires = "view", default_value = "10")]
+    pub limit: usize,
+}

--- a/crates/cairo-profiler/src/cli/mod.rs
+++ b/crates/cairo-profiler/src/cli/mod.rs
@@ -1,0 +1,25 @@
+use crate::cli::build_profile::BuildProfile;
+use crate::cli::view::ViewProfile;
+use clap::{Parser, Subcommand};
+
+pub(crate) mod build_profile;
+pub(crate) mod view;
+
+#[derive(Parser)]
+#[command(version, args_conflicts_with_subcommands = true)]
+#[clap(name = "cairo-profiler")]
+pub struct Cli {
+    #[clap(flatten)]
+    pub build_profile_args: Option<BuildProfile>,
+
+    #[command(subcommand)]
+    pub command: Option<Commands>,
+}
+
+#[derive(Subcommand)]
+pub enum Commands {
+    /// Build the profile from provided trace data
+    BuildProfile(BuildProfile),
+    /// View built profile
+    View(ViewProfile),
+}

--- a/crates/cairo-profiler/src/cli/view.rs
+++ b/crates/cairo-profiler/src/cli/view.rs
@@ -1,0 +1,21 @@
+use camino::Utf8PathBuf;
+use clap::Args;
+
+#[derive(Args)]
+pub struct ViewProfile {
+    /// Path to .pb.gz file with profile data.
+    pub path_to_profile: Utf8PathBuf,
+
+    /// Show the sample in the top view.
+    /// To get the list of available samples use `--list-samples`.
+    #[arg(long, default_value = "steps")]
+    pub sample: String,
+
+    /// List all the samples included in the profile.
+    #[arg(short, long)]
+    pub list_samples: bool,
+
+    /// Set a limit of nodes showed in the top view.
+    #[arg(long, default_value = "10")]
+    pub limit: usize,
+}

--- a/crates/cairo-profiler/src/main.rs
+++ b/crates/cairo-profiler/src/main.rs
@@ -10,108 +10,80 @@ use crate::versioned_constants_reader::read_and_parse_versioned_constants_file;
 use anyhow::{Context, Result};
 use bytes::{Buf, BytesMut};
 use cairo_annotations::trace_data::VersionedCallTrace;
-use camino::Utf8PathBuf;
 use clap::Parser;
+use cli::Cli;
 use flate2::{bufread::GzEncoder, Compression};
 use profile_builder::build_profile;
 use prost::Message;
 
+mod cli;
 mod profile_builder;
 mod profiler_config;
 mod sierra_loader;
 mod trace_reader;
 mod versioned_constants_reader;
 
-#[derive(Parser, Debug)]
-#[command(version)]
-#[clap(name = "cairo-profiler")]
-struct Cli {
-    /// Path to .json with trace data
-    path_to_trace_data: Utf8PathBuf,
-
-    /// Path to the output file
-    #[arg(short, long, default_value = "profile.pb.gz")]
-    output_path: Utf8PathBuf,
-
-    /// Show contract addresses and function selectors in a trace tree
-    #[arg(long)]
-    show_details: bool,
-
-    /// Specify maximum depth of function tree in function level profiling.
-    /// The is applied per entrypoint - each entrypoint function tree is treated separately.
-    #[arg(long, default_value_t = 100)]
-    max_function_stack_trace_depth: usize,
-
-    /// Split non-inlined generic functions based on the type they were monomorphised with.
-    /// E.g. treat `function<felt252>` as different from `function<u8>`.
-    #[arg(long)]
-    split_generics: bool,
-
-    /// Show inlined function in a trace tree. Requires Scarb >= 2.7.0-rc.0 and setting
-    /// `unstable-add-statements-functions-debug-info = true` in `[cairo]` section of Scarb.toml.
-    #[arg(long)]
-    show_inlined_functions: bool,
-
-    /// Path to a file, that includes a map with cost of resources like syscalls.
-    /// If not provided, the cost map will default to the one used on Starknet 0.13.3.
-    /// Files for different Starknet versions can be found in the sequencer repo:
-    /// <https://github.com/starkware-libs/sequencer/blob/main/crates/blockifier/resources/>
-    #[arg(long)]
-    versioned_constants_path: Option<Utf8PathBuf>,
-}
-
 fn main() -> Result<()> {
     let cli = Cli::parse();
 
-    let data = fs::read_to_string(&cli.path_to_trace_data)
-        .context("Failed to read call trace from a file")?;
-    let os_resources_map =
-        read_and_parse_versioned_constants_file(cli.versioned_constants_path.as_ref())
+    match cli.command {
+        None => {
+            let build_cli = &cli.build_profile_args.expect("Failed to parse arguments");
+            let data = fs::read_to_string(&build_cli.path_to_trace_data)
+                .context("Failed to read call trace from a file")?;
+            let os_resources_map = read_and_parse_versioned_constants_file(
+                build_cli.versioned_constants_path.as_ref(),
+            )
             .context("Failed to get resource map from versioned constants file")?;
-    let VersionedCallTrace::V1(serialized_trace) =
-        serde_json::from_str(&data).context("Failed to deserialize call trace")?;
+            let VersionedCallTrace::V1(serialized_trace) =
+                serde_json::from_str(&data).context("Failed to deserialize call trace")?;
 
-    let compiled_artifacts_cache = collect_and_compile_all_sierra_programs(&serialized_trace)?;
-    let profiler_config = ProfilerConfig::from(&cli);
+            let compiled_artifacts_cache =
+                collect_and_compile_all_sierra_programs(&serialized_trace)?;
+            let profiler_config = ProfilerConfig::from(build_cli);
 
-    if profiler_config.show_inlined_functions
-        && !compiled_artifacts_cache.statements_functions_maps_are_present()
-    {
-        eprintln!(
-            "[\x1b[0;33mWARNING\x1b[0m] Mappings used for generating information about \
-        inlined functions are missing. Make sure to add this to your Scarb.toml:\n\
-        [profile.dev.cairo]\nunstable-add-statements-functions-debug-info = true"
-        );
+            if profiler_config.show_inlined_functions
+                && !compiled_artifacts_cache.statements_functions_maps_are_present()
+            {
+                eprintln!(
+                    "[\x1b[0;33mWARNING\x1b[0m] Mappings used for generating information about \
+                inlined functions are missing. Make sure to add this to your Scarb.toml:\n\
+                [profile.dev.cairo]\nunstable-add-statements-functions-debug-info = true"
+                );
+            }
+
+            let samples = collect_samples_from_trace(
+                &serialized_trace,
+                &compiled_artifacts_cache,
+                &profiler_config,
+                &os_resources_map,
+            )?;
+
+            let profile = build_profile(&samples);
+
+            if let Some(parent) = build_cli.output_path.parent() {
+                fs::create_dir_all(parent)
+                    .context("Failed to create parent directories for the output file")?;
+            }
+            let mut file = fs::File::create(&build_cli.output_path)
+                .context("Failed to create the output file")?;
+
+            let mut buffer = BytesMut::new();
+            profile
+                .encode(&mut buffer)
+                .expect("Failed to encode the profile to the buffer");
+
+            let mut buffer_reader = buffer.reader();
+            let mut encoder = GzEncoder::new(&mut buffer_reader, Compression::default());
+
+            let mut encoded = vec![];
+            encoder
+                .read_to_end(&mut encoded)
+                .context("Failed to read bytes from the encoder")?;
+            file.write_all(&encoded).unwrap();
+
+            Ok(())
+        }
+        Some(_) => todo!("new subcommands will be added here"),
     }
-
-    let samples = collect_samples_from_trace(
-        &serialized_trace,
-        &compiled_artifacts_cache,
-        &profiler_config,
-        &os_resources_map,
-    )?;
-
-    let profile = build_profile(&samples);
-
-    if let Some(parent) = cli.output_path.parent() {
-        fs::create_dir_all(parent)
-            .context("Failed to create parent directories for the output file")?;
-    }
-    let mut file = fs::File::create(cli.output_path).context("Failed to create the output file")?;
-
-    let mut buffer = BytesMut::new();
-    profile
-        .encode(&mut buffer)
-        .expect("Failed to encode the profile to the buffer");
-
-    let mut buffer_reader = buffer.reader();
-    let mut encoder = GzEncoder::new(&mut buffer_reader, Compression::default());
-
-    let mut encoded = vec![];
-    encoder
-        .read_to_end(&mut encoded)
-        .context("Failed to read bytes from the encoder")?;
-    file.write_all(&encoded).unwrap();
-
-    Ok(())
 }

--- a/crates/cairo-profiler/src/profiler_config.rs
+++ b/crates/cairo-profiler/src/profiler_config.rs
@@ -1,4 +1,4 @@
-use crate::Cli;
+use crate::cli::build_profile::BuildProfile;
 
 pub struct ProfilerConfig {
     pub show_details: bool,
@@ -7,8 +7,8 @@ pub struct ProfilerConfig {
     pub show_inlined_functions: bool,
 }
 
-impl From<&Cli> for ProfilerConfig {
-    fn from(cli: &Cli) -> ProfilerConfig {
+impl From<&BuildProfile> for ProfilerConfig {
+    fn from(cli: &BuildProfile) -> ProfilerConfig {
         ProfilerConfig {
             show_details: cli.show_details,
             max_function_stack_trace_depth: cli.max_function_stack_trace_depth,


### PR DESCRIPTION
Related to #86 

## Introduced changes

- This PR is a part of the stack that aims to allow for raw text profiling.

## Stack:
--> Set new interface (This PR)
-- Clean up main function (https://github.com/software-mansion/cairo-profiler/pull/131)
-- Add view (raw text profiling) logic (https://github.com/software-mansion/cairo-profiler/pull/132)
-- Add tests for new functionality (https://github.com/software-mansion/cairo-profiler/pull/133)
-- Add docs (https://github.com/software-mansion/cairo-profiler/pull/134)