### PR TITLE
Add option to hide nodes matching regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- new `--hide` option, that allows to filter out nodes from the profile based on passed regex. Resources of the filtered
+  node are added to a parent node (function).
+
 ## [0.8.1] - 2025-02-25
 
 ### Chore

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -388,6 +388,7 @@ dependencies = [
  "prost",
  "prost-build",
  "prost-types",
+ "regex",
  "serde",
  "serde_json",
  "snapbox",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tempfile = "3.16.0"
 indoc = "2"
 cairo-annotations = "0.2.2"
 prettytable-rs = "0.10.0"
+regex = "1.11.1"
 
 cairo-lang-sierra = "2.10.1"
 cairo-lang-sierra-to-casm = "2.10.1"

--- a/crates/cairo-profiler/Cargo.toml
+++ b/crates/cairo-profiler/Cargo.toml
@@ -23,6 +23,7 @@ itertools.workspace = true
 tempfile.workspace = true
 cairo-annotations.workspace = true
 prettytable-rs.workspace = true
+regex.workspace = true
 
 cairo-lang-sierra.workspace = true
 cairo-lang-sierra-to-casm.workspace = true

--- a/crates/cairo-profiler/src/cli/build_profile.rs
+++ b/crates/cairo-profiler/src/cli/build_profile.rs
@@ -40,7 +40,7 @@ pub struct BuildProfile {
     pub show_inlined_functions: bool,
 
     /// Path to a file, that includes a map with cost of resources like syscalls.
-    /// If not provided, the cost map will default to the one used on Starknet 0.13.3.
+    /// If not provided, the cost map will default to the one used on Starknet 0.13.4.
     /// Files for different Starknet versions can be found in the sequencer repo:
     /// <https://github.com/starkware-libs/sequencer/blob/main/crates/blockifier/resources/>
     #[arg(long)]

--- a/crates/cairo-profiler/src/cli/build_profile.rs
+++ b/crates/cairo-profiler/src/cli/build_profile.rs
@@ -103,7 +103,7 @@ pub fn run_build_profile(args: &BuildProfile) -> Result<()> {
     save_profile(&args.output_path, &profile).context("Failed to write profile data to file")?;
 
     if args.view {
-        print_profile(&profile, &args.sample, args.limit, args.hide.as_ref())?;
+        print_profile(&profile, &args.sample, args.limit, args.hide.as_deref())?;
     }
 
     Ok(())

--- a/crates/cairo-profiler/src/cli/build_profile.rs
+++ b/crates/cairo-profiler/src/cli/build_profile.rs
@@ -62,6 +62,12 @@ pub struct BuildProfile {
     /// To view already-built profile run `cairo-profiler view`.
     #[arg(long, requires = "view", default_value = "10")]
     pub limit: NonZeroUsize,
+
+    /// Skip nodes matching regex
+    /// Requires `--view` flag to be set.
+    /// To view already-built profile run `cairo-profiler view`.
+    #[arg(long, requires = "view")]
+    pub hide: Option<String>,
 }
 
 pub fn run_build_profile(args: &BuildProfile) -> Result<()> {
@@ -97,7 +103,7 @@ pub fn run_build_profile(args: &BuildProfile) -> Result<()> {
     save_profile(&args.output_path, &profile).context("Failed to write profile data to file")?;
 
     if args.view {
-        print_profile(&profile, &args.sample, args.limit)?;
+        print_profile(&profile, &args.sample, args.limit, args.hide.as_ref())?;
     }
 
     Ok(())

--- a/crates/cairo-profiler/src/cli/view.rs
+++ b/crates/cairo-profiler/src/cli/view.rs
@@ -21,6 +21,10 @@ pub struct ViewProfile {
     /// Set a limit of nodes showed in the top view.
     #[arg(long, default_value = "10", conflicts_with = "list_samples")]
     pub limit: NonZeroUsize,
+
+    /// Skip nodes matching regex
+    #[arg(long, conflicts_with = "list_samples")]
+    pub hide: Option<String>,
 }
 
 pub fn run_view(args: &ViewProfile) -> Result<()> {
@@ -30,6 +34,6 @@ pub fn run_view(args: &ViewProfile) -> Result<()> {
         println!("{}", samples.join("\n"));
         return Ok(());
     }
-    print_profile(&profile, &args.sample, args.limit)?;
+    print_profile(&profile, &args.sample, args.limit, args.hide.as_ref())?;
     Ok(())
 }

--- a/crates/cairo-profiler/src/cli/view.rs
+++ b/crates/cairo-profiler/src/cli/view.rs
@@ -34,6 +34,6 @@ pub fn run_view(args: &ViewProfile) -> Result<()> {
         println!("{}", samples.join("\n"));
         return Ok(());
     }
-    print_profile(&profile, &args.sample, args.limit, args.hide.as_ref())?;
+    print_profile(&profile, &args.sample, args.limit, args.hide.as_deref())?;
     Ok(())
 }

--- a/crates/cairo-profiler/src/profile_viewer.rs
+++ b/crates/cairo-profiler/src/profile_viewer.rs
@@ -1,5 +1,4 @@
 use crate::profile_builder::pprof::{Function, Location, Profile};
-use anyhow::anyhow;
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
 use flate2::read::GzDecoder;
@@ -25,13 +24,10 @@ struct FunctionProfile {
 fn get_profile_data(
     profile: &Profile,
     sample_name: &str,
-    hide: Option<&String>,
+    hide: Option<&str>,
 ) -> Result<Vec<(String, FunctionProfile)>> {
     let hide_pattern = hide
-        .as_ref()
-        .map(|pattern| {
-            Regex::new(pattern).map_err(|e| anyhow!("Invalid regular expression passed: {}", e))
-        })
+        .map(|pattern| Regex::new(pattern).context("Invalid regular expression passed"))
         .transpose()?;
 
     // Labels in string_table are prefixed with a whitespace
@@ -147,7 +143,7 @@ pub fn print_profile(
     profile: &Profile,
     sample: &str,
     limit: NonZeroUsize,
-    hide: Option<&String>,
+    hide: Option<&str>,
 ) -> Result<()> {
     let data =
         get_profile_data(profile, sample, hide).context("Failed to get data from profile")?;

--- a/crates/cairo-profiler/tests/e2e.rs
+++ b/crates/cairo-profiler/tests/e2e.rs
@@ -265,10 +265,11 @@ fn view_hide_invalid_regex() {
             Error: Failed to get data from profile
             
             Caused by:
-                Invalid regular expression passed: regex parse error:
-                    [core
-                    ^
-                error: unclosed character class
+                0: Invalid regular expression passed
+                1: regex parse error:
+                       [core
+                       ^
+                   error: unclosed character class
             "
         ));
 }

--- a/crates/cairo-profiler/tests/e2e.rs
+++ b/crates/cairo-profiler/tests/e2e.rs
@@ -229,3 +229,172 @@ fn view_range_check_builtin() {
             "#
         ));
 }
+
+#[test]
+fn view_hide_invalid_regex() {
+    let project_root = project_root::get_project_root().unwrap();
+    let temp_dir = assert_fs::TempDir::new().unwrap();
+    temp_dir
+        .copy_from(
+            project_root.join("crates/cairo-profiler/tests/contracts/balance_simple/precompiled/"),
+            &["*.json"],
+        )
+        .unwrap();
+
+    SnapboxCommand::new(cargo_bin!("cairo-profiler"))
+        .current_dir(&temp_dir)
+        .arg("build-profile")
+        .arg("trace_balance_simple.json")
+        .assert()
+        .success();
+
+    SnapboxCommand::new(cargo_bin!("cairo-profiler"))
+        .current_dir(&temp_dir)
+        .arg("view")
+        .arg("profile.pb.gz")
+        .arg("--limit")
+        .arg("2137")
+        .arg("--sample")
+        .arg("steps")
+        .arg("--hide")
+        .arg("[core")
+        .assert()
+        .failure()
+        .stderr_eq(indoc!(
+            r"
+            Error: Failed to get data from profile
+            
+            Caused by:
+                Invalid regular expression passed: regex parse error:
+                    [core
+                    ^
+                error: unclosed character class
+            "
+        ));
+}
+
+#[test]
+fn view_hide_in_view() {
+    let project_root = project_root::get_project_root().unwrap();
+    let temp_dir = assert_fs::TempDir::new().unwrap();
+    temp_dir
+        .copy_from(
+            project_root.join("crates/cairo-profiler/tests/contracts/balance_simple/precompiled/"),
+            &["*.json"],
+        )
+        .unwrap();
+
+    SnapboxCommand::new(cargo_bin!("cairo-profiler"))
+        .current_dir(&temp_dir)
+        .arg("build-profile")
+        .arg("trace_balance_simple.json")
+        .assert()
+        .success();
+
+    // stdout asserts were generated using `go tool pprof -hide "core::*" -top profile.pb.gz` command
+    // as well as `go tool pprof -hide "core" -top profile.pb.gz` command (they should be the same!)
+    // when changing any view_* tests please always generate expected output using this tool
+    // formatting was changed manually, since it differs a bit between pprof and cairo-profiler view
+
+    let expected_output = indoc!(
+        r#"
+
+            Active filter:
+            hide=core
+
+            Showing nodes accounting for 1371 steps, 100.00% of 1371 steps total
+            Showing top 11 nodes out of 11
+
+                  flat |  flat% |    sum% |        cum |    cum% |  
+            -----------+--------+---------+------------+---------+-----------------------------------------------------------------------------------------------
+             827 steps | 60.32% |  60.32% |  827 steps |  60.32% | "CallContract" 
+             145 steps | 10.58% |  70.90% |  170 steps |  12.40% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
+              87 steps |  6.35% |  77.24% |   87 steps |   6.35% | "StorageRead" 
+              81 steps |  5.91% |  83.15% |  144 steps |  10.50% | "snforge_std::cheatcodes::contract_class::declare" 
+              75 steps |  5.47% |  88.62% |   75 steps |   5.47% | "snforge_std::_cheatcode::handle_cheatcode" 
+              53 steps |  3.87% |  92.49% | 1246 steps |  90.88% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
+              38 steps |  2.77% |  95.26% |   38 steps |   2.77% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
+              33 steps |  2.41% |  97.67% |  120 steps |   8.75% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
+              27 steps |  1.97% |  99.64% |  341 steps |  24.87% | "balance_simple_integrationtest::test_contract::deploy_contract" 
+               5 steps |  0.36% | 100.00% | 1371 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
+               0 steps |  0.00% | 100.00% |  120 steps |   8.75% | "Contract: HelloStarknet\nFunction: get_balance\n" 
+            "#
+    );
+
+    SnapboxCommand::new(cargo_bin!("cairo-profiler"))
+        .current_dir(&temp_dir)
+        .arg("view")
+        .arg("profile.pb.gz")
+        .arg("--limit")
+        .arg("2137")
+        .arg("--sample")
+        .arg("steps")
+        .arg("--hide")
+        .arg("core")
+        .assert()
+        .success()
+        .stdout_eq(expected_output);
+}
+
+#[test]
+fn view_hide_in_build() {
+    let project_root = project_root::get_project_root().unwrap();
+    let temp_dir = assert_fs::TempDir::new().unwrap();
+    temp_dir
+        .copy_from(
+            project_root.join("crates/cairo-profiler/tests/contracts/balance_simple/precompiled/"),
+            &["*.json"],
+        )
+        .unwrap();
+
+    SnapboxCommand::new(cargo_bin!("cairo-profiler"))
+        .current_dir(&temp_dir)
+        .arg("build-profile")
+        .arg("trace_balance_simple.json")
+        .assert()
+        .success();
+
+    // stdout asserts were generated using `go tool pprof -hide "core::*" -top profile.pb.gz` command
+    // as well as `go tool pprof -hide "core" -top profile.pb.gz` command (they should be the same!)
+    // when changing any view_* tests please always generate expected output using this tool
+    // formatting was changed manually, since it differs a bit between pprof and cairo-profiler view
+
+    let expected_output = indoc!(
+        r#"
+
+            Active filter:
+            hide=core::*
+
+            Showing nodes accounting for 1371 steps, 100.00% of 1371 steps total
+            Showing top 11 nodes out of 11
+
+                  flat |  flat% |    sum% |        cum |    cum% |  
+            -----------+--------+---------+------------+---------+-----------------------------------------------------------------------------------------------
+             827 steps | 60.32% |  60.32% |  827 steps |  60.32% | "CallContract" 
+             145 steps | 10.58% |  70.90% |  170 steps |  12.40% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
+              87 steps |  6.35% |  77.24% |   87 steps |   6.35% | "StorageRead" 
+              81 steps |  5.91% |  83.15% |  144 steps |  10.50% | "snforge_std::cheatcodes::contract_class::declare" 
+              75 steps |  5.47% |  88.62% |   75 steps |   5.47% | "snforge_std::_cheatcode::handle_cheatcode" 
+              53 steps |  3.87% |  92.49% | 1246 steps |  90.88% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
+              38 steps |  2.77% |  95.26% |   38 steps |   2.77% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
+              33 steps |  2.41% |  97.67% |  120 steps |   8.75% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
+              27 steps |  1.97% |  99.64% |  341 steps |  24.87% | "balance_simple_integrationtest::test_contract::deploy_contract" 
+               5 steps |  0.36% | 100.00% | 1371 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
+               0 steps |  0.00% | 100.00% |  120 steps |   8.75% | "Contract: HelloStarknet\nFunction: get_balance\n" 
+            "#
+    );
+
+    SnapboxCommand::new(cargo_bin!("cairo-profiler"))
+        .current_dir(&temp_dir)
+        .arg("view")
+        .arg("profile.pb.gz")
+        .arg("--limit")
+        .arg("2137")
+        .arg("--sample")
+        .arg("steps")
+        .arg("--hide")
+        .arg("core::*")
+        .assert()
+        .success()
+        .stdout_eq(expected_output);
+}

--- a/crates/cairo-profiler/tests/e2e.rs
+++ b/crates/cairo-profiler/tests/e2e.rs
@@ -302,22 +302,22 @@ fn view_hide_in_view() {
             Active filter:
             hide=core
 
-            Showing nodes accounting for 1371 steps, 100.00% of 1371 steps total
+            Showing nodes accounting for 1410 steps, 100.00% of 1410 steps total
             Showing top 11 nodes out of 11
 
                   flat |  flat% |    sum% |        cum |    cum% |  
             -----------+--------+---------+------------+---------+-----------------------------------------------------------------------------------------------
-             827 steps | 60.32% |  60.32% |  827 steps |  60.32% | "CallContract" 
-             145 steps | 10.58% |  70.90% |  170 steps |  12.40% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
-              87 steps |  6.35% |  77.24% |   87 steps |   6.35% | "StorageRead" 
-              81 steps |  5.91% |  83.15% |  144 steps |  10.50% | "snforge_std::cheatcodes::contract_class::declare" 
-              75 steps |  5.47% |  88.62% |   75 steps |   5.47% | "snforge_std::_cheatcode::handle_cheatcode" 
-              53 steps |  3.87% |  92.49% | 1246 steps |  90.88% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
-              38 steps |  2.77% |  95.26% |   38 steps |   2.77% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
-              33 steps |  2.41% |  97.67% |  120 steps |   8.75% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
-              27 steps |  1.97% |  99.64% |  341 steps |  24.87% | "balance_simple_integrationtest::test_contract::deploy_contract" 
-               5 steps |  0.36% | 100.00% | 1371 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
-               0 steps |  0.00% | 100.00% |  120 steps |   8.75% | "Contract: HelloStarknet\nFunction: get_balance\n" 
+             866 steps | 61.42% |  61.42% |  866 steps |  61.42% | "CallContract" 
+             145 steps | 10.28% |  71.70% |  170 steps |  12.06% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
+              87 steps |  6.17% |  77.87% |   87 steps |   6.17% | "StorageRead" 
+              81 steps |  5.74% |  83.62% |  144 steps |  10.21% | "snforge_std::cheatcodes::contract_class::declare" 
+              75 steps |  5.32% |  88.94% |   75 steps |   5.32% | "snforge_std::_cheatcode::handle_cheatcode" 
+              53 steps |  3.76% |  92.70% | 1285 steps |  91.13% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
+              38 steps |  2.70% |  95.39% |   38 steps |   2.70% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
+              33 steps |  2.34% |  97.73% |  120 steps |   8.51% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
+              27 steps |  1.91% |  99.65% |  341 steps |  24.18% | "balance_simple_integrationtest::test_contract::deploy_contract" 
+               5 steps |  0.35% | 100.00% | 1410 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
+               0 steps |  0.00% | 100.00% |  120 steps |   8.51% | "Contract: HelloStarknet\nFunction: get_balance\n" 
             "#
     );
 
@@ -365,22 +365,22 @@ fn view_hide_in_build() {
             Active filter:
             hide=core::*
 
-            Showing nodes accounting for 1371 steps, 100.00% of 1371 steps total
+            Showing nodes accounting for 1410 steps, 100.00% of 1410 steps total
             Showing top 11 nodes out of 11
 
                   flat |  flat% |    sum% |        cum |    cum% |  
             -----------+--------+---------+------------+---------+-----------------------------------------------------------------------------------------------
-             827 steps | 60.32% |  60.32% |  827 steps |  60.32% | "CallContract" 
-             145 steps | 10.58% |  70.90% |  170 steps |  12.40% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
-              87 steps |  6.35% |  77.24% |   87 steps |   6.35% | "StorageRead" 
-              81 steps |  5.91% |  83.15% |  144 steps |  10.50% | "snforge_std::cheatcodes::contract_class::declare" 
-              75 steps |  5.47% |  88.62% |   75 steps |   5.47% | "snforge_std::_cheatcode::handle_cheatcode" 
-              53 steps |  3.87% |  92.49% | 1246 steps |  90.88% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
-              38 steps |  2.77% |  95.26% |   38 steps |   2.77% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
-              33 steps |  2.41% |  97.67% |  120 steps |   8.75% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
-              27 steps |  1.97% |  99.64% |  341 steps |  24.87% | "balance_simple_integrationtest::test_contract::deploy_contract" 
-               5 steps |  0.36% | 100.00% | 1371 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
-               0 steps |  0.00% | 100.00% |  120 steps |   8.75% | "Contract: HelloStarknet\nFunction: get_balance\n" 
+             866 steps | 61.42% |  61.42% |  866 steps |  61.42% | "CallContract" 
+             145 steps | 10.28% |  71.70% |  170 steps |  12.06% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
+              87 steps |  6.17% |  77.87% |   87 steps |   6.17% | "StorageRead" 
+              81 steps |  5.74% |  83.62% |  144 steps |  10.21% | "snforge_std::cheatcodes::contract_class::declare" 
+              75 steps |  5.32% |  88.94% |   75 steps |   5.32% | "snforge_std::_cheatcode::handle_cheatcode" 
+              53 steps |  3.76% |  92.70% | 1285 steps |  91.13% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
+              38 steps |  2.70% |  95.39% |   38 steps |   2.70% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
+              33 steps |  2.34% |  97.73% |  120 steps |   8.51% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
+              27 steps |  1.91% |  99.65% |  341 steps |  24.18% | "balance_simple_integrationtest::test_contract::deploy_contract" 
+               5 steps |  0.35% | 100.00% | 1410 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
+               0 steps |  0.00% | 100.00% |  120 steps |   8.51% | "Contract: HelloStarknet\nFunction: get_balance\n" 
             "#
     );
 


### PR DESCRIPTION
Related to #109 

[This PR] -> Add Add option to hide nodes matching regex
[[153](https://github.com/software-mansion/cairo-profiler/pull/153)] -> Update docs

## Introduced changes

- Add `--hide` flag to filter out nodes based on regex

## Checklist

- [X] Linked relevant issue
- [ ] Updated relevant documentation (README.md)
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
