### PR TITLE
Add syscall usage count as sample

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - new `--hide` option, that allows to filter out nodes from the profile based on passed regex. Resources of the filtered
   node are added to a parent node (function).
-- sierra gas profiling; in order to profile sierra gas please make sure to run snforge test with `--tracked-resource` flag set to "sierra-gas"
 
 ## [0.8.1] - 2025-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - new `--hide` option, that allows to filter out nodes from the profile based on passed regex. Resources of the filtered
   node are added to a parent node (function).
+- sierra gas profiling; in order to profile sierra gas please make sure to run snforge test with `--tracked-resource` flag set to "sierra-gas"
 
 ## [0.8.1] - 2025-02-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - builtins usage is now included in sierra gas estimations
 - new flag `--show-libfuncs`, allowing to show all libfuncs usage per function (along with its resource consumption)
 - new sample "casm size" to show casm sizes of functions
+- new sample "syscall usage" to show functions' syscall usage count
 
 ## [0.8.2] - 2025-05-06
 

--- a/crates/cairo-profiler/src/trace_reader/function_trace_builder/stack_trace.rs
+++ b/crates/cairo-profiler/src/trace_reader/function_trace_builder/stack_trace.rs
@@ -79,7 +79,7 @@ fn map_syscall_trace_to_sample(
         )
         .unwrap();
 
-    let measurements = if sierra_gas_tracking {
+    let mut measurements = if sierra_gas_tracking {
         calculate_syscall_sierra_gas_measurements(
             syscall_resources,
             invocations,
@@ -88,6 +88,11 @@ fn map_syscall_trace_to_sample(
     } else {
         calculate_syscall_cairo_steps_measurements(syscall_resources, invocations)
     };
+
+    measurements.insert(
+        MeasurementUnit::from("syscall_usage".to_string()),
+        MeasurementValue(invocations),
+    );
 
     Sample {
         call_stack,

--- a/crates/cairo-profiler/src/trace_reader/function_trace_builder/stack_trace.rs
+++ b/crates/cairo-profiler/src/trace_reader/function_trace_builder/stack_trace.rs
@@ -88,6 +88,7 @@ fn map_syscall_trace_to_sample(
     } else {
         calculate_syscall_cairo_steps_measurements(syscall_resources, invocations)
     };
+    dbg!(&measurements);
 
     Sample {
         call_stack,

--- a/crates/cairo-profiler/src/trace_reader/function_trace_builder/stack_trace.rs
+++ b/crates/cairo-profiler/src/trace_reader/function_trace_builder/stack_trace.rs
@@ -88,7 +88,6 @@ fn map_syscall_trace_to_sample(
     } else {
         calculate_syscall_cairo_steps_measurements(syscall_resources, invocations)
     };
-    dbg!(&measurements);
 
     Sample {
         call_stack,


### PR DESCRIPTION
Closes #151 

## Introduced changes

- add new sample "syscall usage" that shows syscall counts per function

## Checklist

- [X] Linked relevant issue
- [X] Updated relevant documentation (README.md)
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
