### PR TITLE
Bump versioned constants and cairo-annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - profiler now correctly removes `::` separators from function names which were monomorphised with different types
 
+### Changed
+
+- upgraded cost map (versioned constants) to starknet 0.14.1
+
 ## [0.10.0] - 2025-07-18
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad8646f98db542e39fc66e68a20b2144f6a732636df7c2354e74645faaa433ce"
+dependencies = [
+ "cfg_aliases",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,12 +196,12 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cairo-annotations"
-version = "0.4.0"
+version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0645a939523208760985169f3053a81bcad5cfb0165f76ee0057f7893e73b86c"
+checksum = "0b4603ce1a6f489cd7b691d06f43cbedf2c720e3d0a7cf2fb07d83757016a637"
 dependencies = [
- "cairo-lang-sierra",
- "cairo-lang-sierra-to-casm",
+ "cairo-lang-sierra 2.12.0",
+ "cairo-lang-sierra-to-casm 2.12.0",
  "camino",
  "derive_more",
  "regex",
@@ -209,7 +218,21 @@ name = "cairo-lang-casm"
 version = "2.11.4"
 source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
 dependencies = [
- "cairo-lang-utils",
+ "cairo-lang-utils 2.11.4",
+ "indoc",
+ "num-bigint",
+ "num-traits",
+ "parity-scale-codec",
+ "serde",
+]
+
+[[package]]
+name = "cairo-lang-casm"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fcb67fa250ab8eb216e626dc58ed04081286885005519875bfbcfbb66485f33"
+dependencies = [
+ "cairo-lang-utils 2.12.0",
  "indoc",
  "num-bigint",
  "num-traits",
@@ -222,7 +245,17 @@ name = "cairo-lang-eq-solver"
 version = "2.11.4"
 source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
 dependencies = [
- "cairo-lang-utils",
+ "cairo-lang-utils 2.11.4",
+ "good_lp",
+]
+
+[[package]]
+name = "cairo-lang-eq-solver"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe2a4ed344b143eceaf818d7212a45a5d6dc9e50ebfc5afabb30ff05d8298261"
+dependencies = [
+ "cairo-lang-utils 2.12.0",
  "good_lp",
 ]
 
@@ -232,9 +265,9 @@ version = "2.11.4"
 source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
 dependencies = [
  "anyhow",
- "cairo-lang-utils",
+ "cairo-lang-utils 2.11.4",
  "const-fnv1a-hash",
- "convert_case",
+ "convert_case 0.7.1",
  "derivative",
  "itertools",
  "lalrpop",
@@ -247,7 +280,34 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "smol_str",
+ "smol_str 0.2.2",
+ "starknet-types-core",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cairo-lang-sierra"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "104eba8e6509ecd4e96cac9cd3dee9f0c698bfc8cba0097b32f6378eaac3edd8"
+dependencies = [
+ "anyhow",
+ "cairo-lang-utils 2.12.0",
+ "const-fnv1a-hash",
+ "convert_case 0.8.0",
+ "derivative",
+ "itertools",
+ "lalrpop",
+ "lalrpop-util",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "regex",
+ "rust-analyzer-salsa",
+ "serde",
+ "serde_json",
+ "sha3",
+ "smol_str 0.3.2",
  "starknet-types-core",
  "thiserror 2.0.12",
 ]
@@ -257,10 +317,26 @@ name = "cairo-lang-sierra-ap-change"
 version = "2.11.4"
 source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
 dependencies = [
- "cairo-lang-eq-solver",
- "cairo-lang-sierra",
- "cairo-lang-sierra-type-size",
- "cairo-lang-utils",
+ "cairo-lang-eq-solver 2.11.4",
+ "cairo-lang-sierra 2.11.4",
+ "cairo-lang-sierra-type-size 2.11.4",
+ "cairo-lang-utils 2.11.4",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cairo-lang-sierra-ap-change"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9131235c4854d3c483a3d363cbfa70b6c2e8b5ca05e37ecbb9edc4a5dfc2e186"
+dependencies = [
+ "cairo-lang-eq-solver 2.12.0",
+ "cairo-lang-sierra 2.12.0",
+ "cairo-lang-sierra-type-size 2.12.0",
+ "cairo-lang-utils 2.12.0",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -272,10 +348,26 @@ name = "cairo-lang-sierra-gas"
 version = "2.11.4"
 source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
 dependencies = [
- "cairo-lang-eq-solver",
- "cairo-lang-sierra",
- "cairo-lang-sierra-type-size",
- "cairo-lang-utils",
+ "cairo-lang-eq-solver 2.11.4",
+ "cairo-lang-sierra 2.11.4",
+ "cairo-lang-sierra-type-size 2.11.4",
+ "cairo-lang-utils 2.11.4",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cairo-lang-sierra-gas"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d9d0fed2440c8ea6717e9580d0efa4b10e07415ca9508afe2d9cb9be8aca64"
+dependencies = [
+ "cairo-lang-eq-solver 2.12.0",
+ "cairo-lang-sierra 2.12.0",
+ "cairo-lang-sierra-type-size 2.12.0",
+ "cairo-lang-utils 2.12.0",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -288,12 +380,33 @@ version = "2.11.4"
 source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
 dependencies = [
  "assert_matches",
- "cairo-lang-casm",
- "cairo-lang-sierra",
- "cairo-lang-sierra-ap-change",
- "cairo-lang-sierra-gas",
- "cairo-lang-sierra-type-size",
- "cairo-lang-utils",
+ "cairo-lang-casm 2.11.4",
+ "cairo-lang-sierra 2.11.4",
+ "cairo-lang-sierra-ap-change 2.11.4",
+ "cairo-lang-sierra-gas 2.11.4",
+ "cairo-lang-sierra-type-size 2.11.4",
+ "cairo-lang-utils 2.11.4",
+ "indoc",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "starknet-types-core",
+ "thiserror 2.0.12",
+]
+
+[[package]]
+name = "cairo-lang-sierra-to-casm"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a47906641d467f18f2035c5017bee4afd6e118eba80e217b82a03b678764919"
+dependencies = [
+ "assert_matches",
+ "cairo-lang-casm 2.12.0",
+ "cairo-lang-sierra 2.12.0",
+ "cairo-lang-sierra-ap-change 2.12.0",
+ "cairo-lang-sierra-gas 2.12.0",
+ "cairo-lang-sierra-type-size 2.12.0",
+ "cairo-lang-utils 2.12.0",
  "indoc",
  "itertools",
  "num-bigint",
@@ -307,8 +420,18 @@ name = "cairo-lang-sierra-type-size"
 version = "2.11.4"
 source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
 dependencies = [
- "cairo-lang-sierra",
- "cairo-lang-utils",
+ "cairo-lang-sierra 2.11.4",
+ "cairo-lang-utils 2.11.4",
+]
+
+[[package]]
+name = "cairo-lang-sierra-type-size"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a7cc6bb50cc23e0252a48a1b2ee9b17edcb74d2dab86c70b095bcd287ecfd66"
+dependencies = [
+ "cairo-lang-sierra 2.12.0",
+ "cairo-lang-utils 2.12.0",
 ]
 
 [[package]]
@@ -316,11 +439,11 @@ name = "cairo-lang-starknet-classes"
 version = "2.11.4"
 source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
 dependencies = [
- "cairo-lang-casm",
- "cairo-lang-sierra",
- "cairo-lang-sierra-to-casm",
- "cairo-lang-utils",
- "convert_case",
+ "cairo-lang-casm 2.11.4",
+ "cairo-lang-sierra 2.11.4",
+ "cairo-lang-sierra-to-casm 2.11.4",
+ "cairo-lang-utils 2.11.4",
+ "convert_case 0.7.1",
  "itertools",
  "num-bigint",
  "num-integer",
@@ -328,7 +451,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "smol_str",
+ "smol_str 0.2.2",
  "starknet-types-core",
  "thiserror 2.0.12",
 ]
@@ -348,6 +471,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "cairo-lang-utils"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3443f4fc17986f362f5b87cd8c37dafeadf5e0a0909a19f2541cd55baae25a74"
+dependencies = [
+ "hashbrown 0.15.4",
+ "indexmap 2.9.0",
+ "itertools",
+ "num-bigint",
+ "num-traits",
+ "schemars",
+ "serde",
+ "smol_str 0.3.2",
+]
+
+[[package]]
 name = "cairo-profiler"
 version = "0.10.0"
 dependencies = [
@@ -355,9 +494,9 @@ dependencies = [
  "assert_fs",
  "bytes",
  "cairo-annotations",
- "cairo-lang-sierra",
- "cairo-lang-sierra-gas",
- "cairo-lang-sierra-to-casm",
+ "cairo-lang-sierra 2.11.4",
+ "cairo-lang-sierra-gas 2.11.4",
+ "cairo-lang-sierra-to-casm 2.11.4",
  "cairo-lang-starknet-classes",
  "camino",
  "clap",
@@ -390,6 +529,12 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "clap"
@@ -481,6 +626,15 @@ name = "convert_case"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
 dependencies = [
  "unicode-segmentation",
 ]
@@ -1647,6 +1801,16 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
 dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "smol_str"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9676b89cd56310a87b93dec47b11af744f34d5fc9f367b829474eec0a891350d"
+dependencies = [
+ "borsh",
  "serde",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ prost-build = { version = "0.14" }
 test-case = "3.3.1"
 itertools = "0.14.0"
 indoc = "2"
-cairo-annotations = "0.4.0"
+cairo-annotations = "0.5.0-rc.2"
 prettytable-rs = "0.10.0"
 regex = "1.11.1"
 console = "0.16.0"

--- a/crates/cairo-profiler/resources/versioned_constants_0_14_1.json
+++ b/crates/cairo-profiler/resources/versioned_constants_0_14_1.json
@@ -1,0 +1,547 @@
+{
+  "tx_event_limits": {
+    "max_data_length": 300,
+    "max_keys_length": 50,
+    "max_n_emitted_events": 1000
+  },
+  "gateway": {
+    "max_calldata_length": 5000,
+    "max_contract_bytecode_size": 81920
+  },
+  "invoke_tx_max_n_steps": 10000000,
+  "deprecated_l2_resource_gas_costs": {
+    "gas_per_data_felt": [
+      128,
+      1000
+    ],
+    "event_key_factor": [
+      2,
+      1
+    ],
+    "gas_per_code_byte": [
+      32,
+      1000
+    ]
+  },
+  "archival_data_gas_costs": {
+    "gas_per_data_felt": [
+      5120,
+      1
+    ],
+    "event_key_factor": [
+      2,
+      1
+    ],
+    "gas_per_code_byte": [
+      1280,
+      1
+    ]
+  },
+  "disable_cairo0_redeclaration": true,
+  "enable_stateful_compression": true,
+  "comprehensive_state_diff": true,
+  "block_direct_execute_call": true,
+  "allocation_cost": {
+    "blob_cost": {
+      "l1_gas": 0,
+      "l1_data_gas": 32,
+      "l2_gas": 0
+    },
+    "gas_cost": {
+      "l1_gas": 551,
+      "l1_data_gas": 0,
+      "l2_gas": 0
+    }
+  },
+  "ignore_inner_event_resources": false,
+  "disable_deploy_in_validation_mode": true,
+  "enable_reverts": true,
+  "max_recursion_depth": 50,
+  "segment_arena_cells": false,
+  "os_constants": {
+    "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
+    "default_entry_point_selector": "0x0",
+    "entry_point_initial_budget": {
+      "step_gas_cost": 100
+    },
+    "entry_point_type_constructor": 2,
+    "entry_point_type_external": 0,
+    "entry_point_type_l1_handler": 1,
+    "error_block_number_out_of_range": "Block number out of range",
+    "error_invalid_input_len": "Invalid input length",
+    "error_invalid_argument": "Invalid argument",
+    "error_out_of_gas": "Out of gas",
+    "error_entry_point_failed": "ENTRYPOINT_FAILED",
+    "error_entry_point_not_found": "ENTRYPOINT_NOT_FOUND",
+    "execute_entry_point_selector": "0x15d40a3d6ca2ac30f4031e42be28da9b056fef9bb7357ac5e85627ee876e5ad",
+    "execute_max_sierra_gas": 1000000000,
+    "default_initial_gas_cost": {
+      "step_gas_cost": 100000000
+    },
+    "l1_gas": "L1_GAS",
+    "l1_gas_index": 0,
+    "l1_handler_version": 0,
+    "l2_gas": "L2_GAS",
+    "l1_data_gas": "L1_DATA",
+    "l1_data_gas_index": 2,
+    "l2_gas_index": 1,
+    "memory_hole_gas_cost": 10,
+    "nop_entry_point_offset": -1,
+    "os_contract_addresses": {
+      "block_hash_contract_address": 1,
+      "alias_contract_address": 2,
+      "reserved_contract_address": 3
+    },
+    "builtin_gas_costs": {
+      "range_check": 70,
+      "range_check96": 56,
+      "keccak": 136189,
+      "pedersen": 4050,
+      "bitwise": 583,
+      "ecop": 4085,
+      "poseidon": 491,
+      "add_mod": 230,
+      "mul_mod": 604,
+      "ecdsa": 10561
+    },
+    "l1_handler_max_amount_bounds": {
+      "l1_gas": 40000,
+      "l1_data_gas": 20000,
+      "l2_gas": 100000000
+    },
+    "sierra_array_len_bound": 4294967296,
+    "step_gas_cost": 100,
+    "stored_block_hash_buffer": 10,
+    "syscall_base_gas_cost": {
+      "step_gas_cost": 100
+    },
+    "transfer_entry_point_selector": "0x83afd3f4caedc6eebf44246fe54e38c95e3179a5ec9ea81740eca5b482d12e",
+    "validate_declare_entry_point_selector": "0x289da278a8dc833409cabfdad1581e8e7d40e42dcaed693fa4008dcdb4963b3",
+    "validate_deploy_entry_point_selector": "0x36fcbf06cd96843058359e1a75928beacfac10727dab22a3972f0af8aa92895",
+    "validate_entry_point_selector": "0x162da33a4585851fe8d3af3c2a9c60b557814e221e0d4f30ff0b2189d9c7775",
+    "validate_max_sierra_gas": 100000000,
+    "validate_rounding_consts": {
+      "validate_block_number_rounding": 100,
+      "validate_timestamp_rounding": 3600
+    },
+    "validated": "VALID",
+    "v1_bound_accounts_cairo0": [
+      "0x06d706cfbac9b8262d601c38251c5fbe0497c3a96cc91a92b08d91b61d9e70c4",
+      "0x0309c042d3729173c7f2f91a34f04d8c509c1b292d334679ef1aabf8da0899cc",
+      "0x01a7820094feaf82d53f53f214b81292d717e7bb9a92bb2488092cd306f3993f",
+      "0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2",
+      "0x041cb0280ebadaa75f996d8d92c6f265f6d040bb3ba442e5f86a554f1765244e"
+    ],
+    "v1_bound_accounts_cairo1": [
+      "0x01a736d6ed154502257f02b1ccdf4d9d1089f80811cd6acad48e6b6a9d1f2003",
+      "0x0737ee2f87ce571a58c6c8da558ec18a07ceb64a6172d5ec46171fbc80077a48",
+      "0x05400e90f7e0ae78bd02c77cd75527280470e2fe19c54970dd79dc37a9d3645c",
+      "0x04c6d6cf894f8bc96bb9c525e6853e5483177841f7388f74a46cfda6f028c755",
+      "0x01c0bb51e2ce73dc007601a1e7725453627254016c28f118251a71bbb0507fcb",
+      "0x0251830adc3d8b4d818c2c309d71f1958308e8c745212480c26e01120c69ee49",
+      "0x0251cac7b2f45d255b83b7a06dcdef70c8a8752f00ea776517c1c2243c7a06e5"
+    ],
+    "v1_bound_accounts_max_tip": "0x746a5288000",
+    "data_gas_accounts": [
+      "0x02c8c7e6fbcfb3e8e15a46648e8914c6aa1fc506fc1e7fb3d1e19630716174bc",
+      "0x00816dd0297efc55dc1e7559020a3a825e81ef734b558f03c83325d4da7e6253",
+      "0x041bf1e71792aecb9df3e9d04e1540091c5e13122a731e02bec588f71dc1a5c3",
+      "0x6d612cac7690e6620055c617a83a5a0b43b9758d9d30f281ddbc77be1651a70"
+    ]
+  },
+  "os_resources": {
+    "execute_syscalls": {
+      "CallContract": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 18
+        },
+        "n_memory_holes": 0,
+        "n_steps": 903
+      },
+      "DelegateCall": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 19
+        },
+        "n_memory_holes": 0,
+        "n_steps": 713
+      },
+      "DelegateL1Handler": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 15
+        },
+        "n_memory_holes": 0,
+        "n_steps": 692
+      },
+      "Deploy": {
+        "constant": {
+          "builtin_instance_counter": {
+            "pedersen_builtin": 7,
+            "range_check_builtin": 21
+          },
+          "n_memory_holes": 0,
+          "n_steps": 1173
+        },
+        "calldata_factor": {
+          "builtin_instance_counter": {
+            "pedersen_builtin": 1
+          },
+          "n_memory_holes": 0,
+          "n_steps": 8
+        }
+      },
+      "EmitEvent": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0,
+        "n_steps": 61
+      },
+      "GetBlockHash": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 2
+        },
+        "n_memory_holes": 0,
+        "n_steps": 107
+      },
+      "GetBlockNumber": {
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0,
+        "n_steps": 40
+      },
+      "GetBlockTimestamp": {
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0,
+        "n_steps": 38
+      },
+      "GetCallerAddress": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 2
+        },
+        "n_memory_holes": 0,
+        "n_steps": 125
+      },
+      "GetClassHashAt": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0,
+        "n_steps": 89
+      },
+      "GetContractAddress": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 2
+        },
+        "n_memory_holes": 0,
+        "n_steps": 125
+      },
+      "GetExecutionInfo": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 2
+        },
+        "n_memory_holes": 0,
+        "n_steps": 125
+      },
+      "GetSequencerAddress": {
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0,
+        "n_steps": 34
+      },
+      "GetTxInfo": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 2
+        },
+        "n_memory_holes": 0,
+        "n_steps": 125
+      },
+      "GetTxSignature": {
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0,
+        "n_steps": 44
+      },
+      "Keccak": {
+        "builtin_instance_counter": {},
+        "n_memory_holes": 0,
+        "n_steps": 100
+      },
+      "KeccakRound": {
+        "builtin_instance_counter": {
+          "bitwise_builtin": 6,
+          "keccak_builtin": 1,
+          "range_check_builtin": 56
+        },
+        "n_memory_holes": 0,
+        "n_steps": 281
+      },
+      "LibraryCall": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 18
+        },
+        "n_memory_holes": 0,
+        "n_steps": 879
+      },
+      "LibraryCallL1Handler": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 15
+        },
+        "n_memory_holes": 0,
+        "n_steps": 659
+      },
+      "MetaTxV0": {
+        "constant": {
+          "builtin_instance_counter": {
+            "pedersen_builtin": 9,
+            "range_check_builtin": 20
+          },
+          "n_memory_holes": 0,
+          "n_steps": 1301
+        },
+        "calldata_factor": {
+          "builtin_instance_counter": {
+            "pedersen_builtin": 1
+          },
+          "n_memory_holes": 0,
+          "n_steps": 8
+        }
+      },
+      "ReplaceClass": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0,
+        "n_steps": 106
+      },
+      "Secp256k1Add": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 29
+        },
+        "n_memory_holes": 0,
+        "n_steps": 412
+      },
+      "Secp256k1GetPointFromX": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 30
+        },
+        "n_memory_holes": 0,
+        "n_steps": 397
+      },
+      "Secp256k1GetXy": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 11
+        },
+        "n_memory_holes": 0,
+        "n_steps": 209
+      },
+      "Secp256k1Mul": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 7045
+        },
+        "n_memory_holes": 0,
+        "n_steps": 76507
+      },
+      "Secp256k1New": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 35
+        },
+        "n_memory_holes": 0,
+        "n_steps": 463
+      },
+      "Secp256r1Add": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 57
+        },
+        "n_memory_holes": 0,
+        "n_steps": 595
+      },
+      "Secp256r1GetPointFromX": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 44
+        },
+        "n_memory_holes": 0,
+        "n_steps": 516
+      },
+      "Secp256r1GetXy": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 11
+        },
+        "n_memory_holes": 0,
+        "n_steps": 211
+      },
+      "Secp256r1Mul": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 13961
+        },
+        "n_memory_holes": 0,
+        "n_steps": 125346
+      },
+      "Secp256r1New": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 49
+        },
+        "n_memory_holes": 0,
+        "n_steps": 582
+      },
+      "SendMessageToL1": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0,
+        "n_steps": 144
+      },
+      "Sha256ProcessBlock": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 65,
+          "bitwise_builtin": 1115
+        },
+        "n_memory_holes": 0,
+        "n_steps": 1867
+      },
+      "StorageRead": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0,
+        "n_steps": 90
+      },
+      "StorageWrite": {
+        "builtin_instance_counter": {
+          "range_check_builtin": 1
+        },
+        "n_memory_holes": 0,
+        "n_steps": 96
+      }
+    },
+    "execute_txs_inner": {
+      "Declare": {
+        "builtin_instance_counter": {
+          "pedersen_builtin": 4,
+          "range_check_builtin": 72,
+          "poseidon_builtin": 15
+        },
+        "n_memory_holes": 0,
+        "n_steps": 3523
+      },
+      "DeployAccount": {
+        "constant": {
+          "builtin_instance_counter": {
+            "pedersen_builtin": 11,
+            "range_check_builtin": 93,
+            "poseidon_builtin": 11
+          },
+          "n_memory_holes": 0,
+          "n_steps": 4583
+        },
+        "calldata_factor": {
+          "resources": {
+            "builtin_instance_counter": {
+              "poseidon_builtin": 1,
+              "pedersen_builtin": 2
+            },
+            "n_memory_holes": 0,
+            "n_steps": 37
+          },
+          "scaling_factor": 2
+        }
+      },
+      "InvokeFunction": {
+        "constant": {
+          "builtin_instance_counter": {
+            "pedersen_builtin": 4,
+            "range_check_builtin": 90,
+            "poseidon_builtin": 12
+          },
+          "n_memory_holes": 0,
+          "n_steps": 4348
+        },
+        "calldata_factor": {
+          "resources": {
+            "builtin_instance_counter": {
+              "poseidon_builtin": 1
+            },
+            "n_memory_holes": 0,
+            "n_steps": 11
+          },
+          "scaling_factor": 2
+        }
+      },
+      "L1Handler": {
+        "constant": {
+          "builtin_instance_counter": {
+            "pedersen_builtin": 11,
+            "range_check_builtin": 19
+          },
+          "n_memory_holes": 0,
+          "n_steps": 1315
+        },
+        "calldata_factor": {
+          "builtin_instance_counter": {
+            "pedersen_builtin": 1
+          },
+          "n_memory_holes": 0,
+          "n_steps": 13
+        }
+      }
+    },
+    "compute_os_kzg_commitment_info": {
+      "builtin_instance_counter": {
+        "range_check_builtin": 17
+      },
+      "n_memory_holes": 0,
+      "n_steps": 113
+    }
+  },
+  "validate_max_n_steps": 1000000,
+  "min_sierra_version_for_sierra_gas": "1.7.0",
+  "vm_resource_fee_cost": {
+    "builtins": {
+      "add_mod_builtin": [
+        4,
+        100
+      ],
+      "bitwise_builtin": [
+        16,
+        100
+      ],
+      "ec_op_builtin": [
+        256,
+        100
+      ],
+      "ecdsa_builtin": [
+        512,
+        100
+      ],
+      "keccak_builtin": [
+        512,
+        100
+      ],
+      "mul_mod_builtin": [
+        4,
+        100
+      ],
+      "output_builtin": [
+        0,
+        1
+      ],
+      "pedersen_builtin": [
+        8,
+        100
+      ],
+      "poseidon_builtin": [
+        8,
+        100
+      ],
+      "range_check_builtin": [
+        4,
+        100
+      ],
+      "range_check96_builtin": [
+        4,
+        100
+      ]
+    },
+    "n_steps": [
+      25,
+      10000
+    ]
+  },
+  "enable_tip": true
+}

--- a/crates/cairo-profiler/src/cli/build_profile.rs
+++ b/crates/cairo-profiler/src/cli/build_profile.rs
@@ -41,7 +41,7 @@ pub struct BuildProfile {
     pub show_inlined_functions: bool,
 
     /// Path to a file, that includes a map with cost of resources like syscalls.
-    /// If not provided, the cost map will default to the one used on Starknet 0.13.4.
+    /// If not provided, the cost map will default to the one used on Starknet 0.14.1.
     /// Files for different Starknet versions can be found in the sequencer repo:
     /// <https://github.com/starkware-libs/sequencer/blob/main/crates/blockifier/resources/>
     #[arg(long)]

--- a/crates/cairo-profiler/src/trace_reader/function_trace_builder/stack_trace.rs
+++ b/crates/cairo-profiler/src/trace_reader/function_trace_builder/stack_trace.rs
@@ -1,5 +1,6 @@
 use crate::trace_reader::function_trace_builder::ChargedResources;
 use crate::trace_reader::sample::{FunctionCall, MeasurementUnit, MeasurementValue, Sample};
+use crate::versioned_constants_reader::SyscallVariant::{Scaled, Unscaled};
 use crate::versioned_constants_reader::{BuiltinGasCosts, VersionedConstants};
 use cairo_annotations::trace_data::{DeprecatedSyscallSelector, VmExecutionResources};
 use cairo_lang_sierra::extensions::starknet::StarknetConcreteLibfunc;
@@ -79,14 +80,19 @@ pub fn map_syscall_trace_to_sample(
         )
         .unwrap();
 
+    let adjusted_resources = match syscall_resources {
+        Unscaled(resources) => resources,
+        Scaled(resources) => &resources.constant,
+    };
+
     let mut measurements = if sierra_gas_tracking {
         calculate_syscall_sierra_gas_measurements(
-            syscall_resources,
+            adjusted_resources,
             invocations,
             versioned_constants,
         )
     } else {
-        calculate_syscall_cairo_steps_measurements(syscall_resources, invocations)
+        calculate_syscall_cairo_steps_measurements(adjusted_resources, invocations)
     };
 
     measurements.insert(
@@ -214,6 +220,7 @@ pub fn map_syscall_to_selector(syscall: &StarknetConcreteLibfunc) -> DeprecatedS
         StarknetConcreteLibfunc::Sha256ProcessBlock(_) => {
             DeprecatedSyscallSelector::Sha256ProcessBlock
         }
+        StarknetConcreteLibfunc::MetaTxV0(_) => DeprecatedSyscallSelector::MetaTxV0,
         _ => panic!("Missing mapping to a syscall"),
     }
 }

--- a/crates/cairo-profiler/src/versioned_constants_reader.rs
+++ b/crates/cairo-profiler/src/versioned_constants_reader.rs
@@ -22,7 +22,20 @@ pub struct OsConstants {
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct OsResources {
-    pub execute_syscalls: HashMap<DeprecatedSyscallSelector, VmExecutionResources>,
+    pub execute_syscalls: HashMap<DeprecatedSyscallSelector, SyscallVariant>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SyscallVariant {
+    Scaled(ScaledResources),
+    Unscaled(VmExecutionResources),
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct ScaledResources {
+    pub constant: VmExecutionResources,
+    pub calldata_factor: VmExecutionResources,
 }
 
 #[derive(Debug, Default, Serialize, Deserialize)]
@@ -53,7 +66,7 @@ pub fn read_and_parse_versioned_constants_file(
         Some(path) => fs::read_to_string(path).with_context(|| {
             format!("Cannot read versioned constants file at specified path {path}")
         })?,
-        None => include_str!("../resources/versioned_constants_0_13_4.json").to_string(),
+        None => include_str!("../resources/versioned_constants_0_14_1.json").to_string(),
     };
     let json_value: Value = serde_json::from_str(&file_content)
         .context("Failed to parse versioned constants file content")?;

--- a/crates/cairo-profiler/tests/data/missing_syscall_versioned_constants.json
+++ b/crates/cairo-profiler/tests/data/missing_syscall_versioned_constants.json
@@ -291,6 +291,11 @@
             "GetClassHashAt": {
                 "n_steps": 0,
                 "builtin_instance_counter": {},
+                "n_memory_holes": 0,
+            },
+            "MetaTxV0": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
                 "n_memory_holes": 0
             }
         }

--- a/crates/cairo-profiler/tests/data/test_versioned_constants.json
+++ b/crates/cairo-profiler/tests/data/test_versioned_constants.json
@@ -299,6 +299,11 @@
                 "n_steps": 0,
                 "builtin_instance_counter": {},
                 "n_memory_holes": 0
+            },
+            "MetaTxV0": {
+                "n_steps": 0,
+                "builtin_instance_counter": {},
+                "n_memory_holes": 0
             }
         }
     }


### PR DESCRIPTION
## Introduced changes

This PR is a part of a bigger stack with an end goal to add support for calldata factor.

The PRs are:
--> Bump versioned constants to 0.14.1 (This PR)
-- Bump cairo to 2.12 (rc), use new cairo cost estimation interface (https://github.com/software-mansion/cairo-profiler/pull/198) 
-- Refactor `function_trace_builder` function (https://github.com/software-mansion/cairo-profiler/pull/199)
-- Display contract entrypoints as called from functions (https://github.com/software-mansion/cairo-profiler/pull/200)
-- Add tests for new tree structure (https://github.com/software-mansion/cairo-profiler/pull/201)
-- Factor in calldata factor for scaled syscalls (https://github.com/software-mansion/cairo-profiler/pull/202)
-- Add tests for calldata factor (https://github.com/software-mansion/cairo-profiler/pull/203)
-- Bump cairo and cairo annotations to their latest stable versions (https://github.com/software-mansion/cairo-profiler/pull/206)

## Checklist

- [ ] Linked relevant issue
- [ ] Updated relevant documentation (README.md)
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
