### PR TITLE
Bump cairo; use new cost estimation interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -200,8 +200,8 @@ version = "0.5.0-rc.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b4603ce1a6f489cd7b691d06f43cbedf2c720e3d0a7cf2fb07d83757016a637"
 dependencies = [
- "cairo-lang-sierra 2.12.0",
- "cairo-lang-sierra-to-casm 2.12.0",
+ "cairo-lang-sierra",
+ "cairo-lang-sierra-to-casm",
  "camino",
  "derive_more",
  "regex",
@@ -215,38 +215,16 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-casm"
-version = "2.11.4"
-source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
-dependencies = [
- "cairo-lang-utils 2.11.4",
- "indoc",
- "num-bigint",
- "num-traits",
- "parity-scale-codec",
- "serde",
-]
-
-[[package]]
-name = "cairo-lang-casm"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fcb67fa250ab8eb216e626dc58ed04081286885005519875bfbcfbb66485f33"
 dependencies = [
- "cairo-lang-utils 2.12.0",
+ "cairo-lang-utils",
  "indoc",
  "num-bigint",
  "num-traits",
  "parity-scale-codec",
  "serde",
-]
-
-[[package]]
-name = "cairo-lang-eq-solver"
-version = "2.11.4"
-source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
-dependencies = [
- "cairo-lang-utils 2.11.4",
- "good_lp",
 ]
 
 [[package]]
@@ -255,34 +233,8 @@ version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe2a4ed344b143eceaf818d7212a45a5d6dc9e50ebfc5afabb30ff05d8298261"
 dependencies = [
- "cairo-lang-utils 2.12.0",
+ "cairo-lang-utils",
  "good_lp",
-]
-
-[[package]]
-name = "cairo-lang-sierra"
-version = "2.11.4"
-source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
-dependencies = [
- "anyhow",
- "cairo-lang-utils 2.11.4",
- "const-fnv1a-hash",
- "convert_case 0.7.1",
- "derivative",
- "itertools",
- "lalrpop",
- "lalrpop-util",
- "num-bigint",
- "num-integer",
- "num-traits",
- "regex",
- "rust-analyzer-salsa",
- "serde",
- "serde_json",
- "sha3",
- "smol_str 0.2.2",
- "starknet-types-core",
- "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -292,9 +244,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "104eba8e6509ecd4e96cac9cd3dee9f0c698bfc8cba0097b32f6378eaac3edd8"
 dependencies = [
  "anyhow",
- "cairo-lang-utils 2.12.0",
+ "cairo-lang-utils",
  "const-fnv1a-hash",
- "convert_case 0.8.0",
+ "convert_case",
  "derivative",
  "itertools",
  "lalrpop",
@@ -307,23 +259,8 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "smol_str 0.3.2",
+ "smol_str",
  "starknet-types-core",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "cairo-lang-sierra-ap-change"
-version = "2.11.4"
-source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
-dependencies = [
- "cairo-lang-eq-solver 2.11.4",
- "cairo-lang-sierra 2.11.4",
- "cairo-lang-sierra-type-size 2.11.4",
- "cairo-lang-utils 2.11.4",
- "itertools",
- "num-bigint",
- "num-traits",
  "thiserror 2.0.12",
 ]
 
@@ -333,25 +270,10 @@ version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9131235c4854d3c483a3d363cbfa70b6c2e8b5ca05e37ecbb9edc4a5dfc2e186"
 dependencies = [
- "cairo-lang-eq-solver 2.12.0",
- "cairo-lang-sierra 2.12.0",
- "cairo-lang-sierra-type-size 2.12.0",
- "cairo-lang-utils 2.12.0",
- "itertools",
- "num-bigint",
- "num-traits",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "cairo-lang-sierra-gas"
-version = "2.11.4"
-source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
-dependencies = [
- "cairo-lang-eq-solver 2.11.4",
- "cairo-lang-sierra 2.11.4",
- "cairo-lang-sierra-type-size 2.11.4",
- "cairo-lang-utils 2.11.4",
+ "cairo-lang-eq-solver",
+ "cairo-lang-sierra",
+ "cairo-lang-sierra-type-size",
+ "cairo-lang-utils",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -364,33 +286,13 @@ version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d9d0fed2440c8ea6717e9580d0efa4b10e07415ca9508afe2d9cb9be8aca64"
 dependencies = [
- "cairo-lang-eq-solver 2.12.0",
- "cairo-lang-sierra 2.12.0",
- "cairo-lang-sierra-type-size 2.12.0",
- "cairo-lang-utils 2.12.0",
+ "cairo-lang-eq-solver",
+ "cairo-lang-sierra",
+ "cairo-lang-sierra-type-size",
+ "cairo-lang-utils",
  "itertools",
  "num-bigint",
  "num-traits",
- "thiserror 2.0.12",
-]
-
-[[package]]
-name = "cairo-lang-sierra-to-casm"
-version = "2.11.4"
-source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
-dependencies = [
- "assert_matches",
- "cairo-lang-casm 2.11.4",
- "cairo-lang-sierra 2.11.4",
- "cairo-lang-sierra-ap-change 2.11.4",
- "cairo-lang-sierra-gas 2.11.4",
- "cairo-lang-sierra-type-size 2.11.4",
- "cairo-lang-utils 2.11.4",
- "indoc",
- "itertools",
- "num-bigint",
- "num-traits",
- "starknet-types-core",
  "thiserror 2.0.12",
 ]
 
@@ -401,12 +303,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a47906641d467f18f2035c5017bee4afd6e118eba80e217b82a03b678764919"
 dependencies = [
  "assert_matches",
- "cairo-lang-casm 2.12.0",
- "cairo-lang-sierra 2.12.0",
- "cairo-lang-sierra-ap-change 2.12.0",
- "cairo-lang-sierra-gas 2.12.0",
- "cairo-lang-sierra-type-size 2.12.0",
- "cairo-lang-utils 2.12.0",
+ "cairo-lang-casm",
+ "cairo-lang-sierra",
+ "cairo-lang-sierra-ap-change",
+ "cairo-lang-sierra-gas",
+ "cairo-lang-sierra-type-size",
+ "cairo-lang-utils",
  "indoc",
  "itertools",
  "num-bigint",
@@ -417,33 +319,25 @@ dependencies = [
 
 [[package]]
 name = "cairo-lang-sierra-type-size"
-version = "2.11.4"
-source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
-dependencies = [
- "cairo-lang-sierra 2.11.4",
- "cairo-lang-utils 2.11.4",
-]
-
-[[package]]
-name = "cairo-lang-sierra-type-size"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a7cc6bb50cc23e0252a48a1b2ee9b17edcb74d2dab86c70b095bcd287ecfd66"
 dependencies = [
- "cairo-lang-sierra 2.12.0",
- "cairo-lang-utils 2.12.0",
+ "cairo-lang-sierra",
+ "cairo-lang-utils",
 ]
 
 [[package]]
 name = "cairo-lang-starknet-classes"
-version = "2.11.4"
-source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d46f87d7dc5ee23ff1e67cb88210f3273ee97b82efc84e30f5abf17a96d7510"
 dependencies = [
- "cairo-lang-casm 2.11.4",
- "cairo-lang-sierra 2.11.4",
- "cairo-lang-sierra-to-casm 2.11.4",
- "cairo-lang-utils 2.11.4",
- "convert_case 0.7.1",
+ "cairo-lang-casm",
+ "cairo-lang-sierra",
+ "cairo-lang-sierra-to-casm",
+ "cairo-lang-utils",
+ "convert_case",
  "itertools",
  "num-bigint",
  "num-integer",
@@ -451,23 +345,9 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3",
- "smol_str 0.2.2",
+ "smol_str",
  "starknet-types-core",
  "thiserror 2.0.12",
-]
-
-[[package]]
-name = "cairo-lang-utils"
-version = "2.11.4"
-source = "git+https://github.com/ksew1/cairo.git?branch=2.11.4-sierra-gas-pub#ff37d940498f224748b772f68114eb2989b8b625"
-dependencies = [
- "hashbrown 0.15.4",
- "indexmap 2.9.0",
- "itertools",
- "num-bigint",
- "num-traits",
- "schemars",
- "serde",
 ]
 
 [[package]]
@@ -483,7 +363,7 @@ dependencies = [
  "num-traits",
  "schemars",
  "serde",
- "smol_str 0.3.2",
+ "smol_str",
 ]
 
 [[package]]
@@ -494,10 +374,13 @@ dependencies = [
  "assert_fs",
  "bytes",
  "cairo-annotations",
- "cairo-lang-sierra 2.11.4",
- "cairo-lang-sierra-gas 2.11.4",
- "cairo-lang-sierra-to-casm 2.11.4",
+ "cairo-lang-sierra",
+ "cairo-lang-sierra-ap-change",
+ "cairo-lang-sierra-gas",
+ "cairo-lang-sierra-to-casm",
+ "cairo-lang-sierra-type-size",
  "cairo-lang-starknet-classes",
+ "cairo-lang-utils",
  "camino",
  "clap",
  "console",
@@ -619,15 +502,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb402b8d4c85569410425650ce3eddc7d698ed96d39a73f941b08fb63082f1e7"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -1794,15 +1668,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "smol_str"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd538fb6910ac1099850255cf94a94df6551fbdd602454387d0adb2d1ca6dead"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "smol_str"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,13 +32,10 @@ prettytable-rs = "0.10.0"
 regex = "1.11.1"
 console = "0.16.0"
 
-cairo-lang-sierra = "2.11.4"
-cairo-lang-sierra-to-casm = "2.11.4"
-cairo-lang-starknet-classes = "2.11.4"
-cairo-lang-sierra-gas = "2.11.4"
-
-[patch.crates-io]
-cairo-lang-sierra = { git = "https://github.com/ksew1/cairo.git", branch = "2.11.4-sierra-gas-pub" }
-cairo-lang-sierra-to-casm = { git = "https://github.com/ksew1/cairo.git", branch = "2.11.4-sierra-gas-pub" }
-cairo-lang-starknet-classes = { git = "https://github.com/ksew1/cairo.git", branch = "2.11.4-sierra-gas-pub" }
-cairo-lang-sierra-gas = { git = "https://github.com/ksew1/cairo.git", branch = "2.11.4-sierra-gas-pub" }
+cairo-lang-sierra = "2.12.0-rc.0"
+cairo-lang-sierra-to-casm = "2.12.0-rc.0"
+cairo-lang-starknet-classes = "2.12.0-rc.0"
+cairo-lang-sierra-gas = "2.12.0-rc.0"
+cairo-lang-sierra-type-size = "2.12.0-rc.0"
+cairo-lang-sierra-ap-change = "2.12.0-rc.0"
+cairo-lang-utils = "2.12.0-rc.0"

--- a/crates/cairo-profiler/Cargo.toml
+++ b/crates/cairo-profiler/Cargo.toml
@@ -28,6 +28,9 @@ cairo-lang-sierra.workspace = true
 cairo-lang-sierra-to-casm.workspace = true
 cairo-lang-starknet-classes.workspace = true
 cairo-lang-sierra-gas.workspace = true
+cairo-lang-sierra-type-size.workspace = true
+cairo-lang-sierra-ap-change.workspace = true
+cairo-lang-utils.workspace = true
 
 [dev-dependencies]
 assert_fs.workspace = true

--- a/crates/cairo-profiler/src/trace_reader/function_trace_builder.rs
+++ b/crates/cairo-profiler/src/trace_reader/function_trace_builder.rs
@@ -150,8 +150,9 @@ pub fn collect_function_level_profiling_info(
     // That's why we must track entry to a syscall, and leave as soon as we're out of given GenStatement::Invocation
     let mut in_syscall_idx: Option<StatementIdx> = None;
     // similarly to syscalls, used to track entry to a libfunc (based on steps costs)
-    // default value is 1, because this is a minimal trace count (ie one trace is one step)
-    let mut libfunc_appearance_tracker = 1;
+    // default value is 100, because this is a minimal trace cost of a single trace
+    // (ie one trace is one step which is 100 sierra gas)
+    let mut libfunc_appearance_tracker = 100;
 
     let libfunc_map: HashMap<u64, String> = program
         .libfunc_declarations

--- a/crates/cairo-profiler/src/trace_reader/function_trace_builder.rs
+++ b/crates/cairo-profiler/src/trace_reader/function_trace_builder.rs
@@ -1,5 +1,6 @@
 use crate::profiler_config::FunctionLevelConfig;
 use crate::trace_reader::function_name::FunctionNameExt;
+use crate::trace_reader::function_trace_builder::cost::{CostEntry, ProfilerInvocationInfo};
 use crate::trace_reader::function_trace_builder::function_stack_trace::{
     CallStack, VecWithLimitedCapacity,
 };
@@ -17,13 +18,16 @@ use cairo_lang_sierra::extensions::gas::CostTokenType;
 use cairo_lang_sierra::extensions::starknet::StarknetConcreteLibfunc;
 use cairo_lang_sierra::program::{GenStatement, Program, StatementIdx};
 use cairo_lang_sierra::program_registry::ProgramRegistry;
-use cairo_lang_sierra_gas::ComputeCostInfoProvider;
-use cairo_lang_sierra_gas::core_libfunc_cost_base::core_libfunc_cost;
-use cairo_lang_sierra_gas::objects::{BranchCost, ConstCost, PreCost};
+use cairo_lang_sierra_gas::compute_precost_info;
+use cairo_lang_sierra_gas::core_libfunc_cost::core_libfunc_cost;
+use cairo_lang_sierra_to_casm::circuit::CircuitsInfo;
 use cairo_lang_sierra_to_casm::compiler::CairoProgramDebugInfo;
+use cairo_lang_sierra_to_casm::metadata::{MetadataComputationConfig, calc_metadata};
+use cairo_lang_sierra_type_size::get_type_size_map;
 use std::collections::HashMap;
 use std::ops::{AddAssign, SubAssign};
 
+mod cost;
 mod function_stack_trace;
 mod inlining;
 pub mod stack_trace;
@@ -112,7 +116,19 @@ pub fn collect_function_level_profiling_info(
     sierra_gas_tracking: bool,
 ) -> FunctionLevelProfilingInfo {
     let sierra_program_registry = &ProgramRegistry::<CoreType, CoreLibfunc>::new(program).unwrap();
-    let cost_info_provider = ComputeCostInfoProvider::new(program).unwrap();
+    let precost_info = compute_precost_info(program).expect("Failed to compute pre-cost info");
+
+    let circuits_info = CircuitsInfo::new(
+        sierra_program_registry,
+        program.type_declarations.iter().map(|td| &td.id),
+    )
+    .expect("Failed to compute circuits info");
+    let type_sizes =
+        get_type_size_map(program, sierra_program_registry).expect("Failed to get type-size map");
+
+    let metadata_config = MetadataComputationConfig::default();
+    let metadata =
+        calc_metadata(program, metadata_config.clone()).expect("Failed to compute metadata");
 
     let mut call_stack = CallStack::new(function_level_config.max_function_stack_trace_depth);
 
@@ -136,15 +152,6 @@ pub fn collect_function_level_profiling_info(
     // similarly to syscalls, used to track entry to a libfunc (based on steps costs)
     // default value is 1, because this is a minimal trace count (ie one trace is one step)
     let mut libfunc_appearance_tracker = 1;
-
-    let builtins_with_cost = [
-        CostTokenType::Bitwise,
-        CostTokenType::Pedersen,
-        CostTokenType::Poseidon,
-        CostTokenType::EcOp,
-        CostTokenType::AddMod,
-        CostTokenType::MulMod,
-    ];
 
     let libfunc_map: HashMap<u64, String> = program
         .libfunc_declarations
@@ -217,6 +224,13 @@ pub fn collect_function_level_profiling_info(
             panic!("Failed fetching statement index {}", sierra_statement_idx.0);
         };
 
+        let profiler_info_provider = ProfilerInvocationInfo {
+            type_sizes: &type_sizes,
+            circuits_info: &circuits_info,
+            metadata: &metadata,
+            idx: sierra_statement_idx,
+        };
+
         match gen_statement {
             GenStatement::Invocation(invocation) => {
                 let libfunc = sierra_program_registry.get_libfunc(&invocation.libfunc_id);
@@ -244,7 +258,8 @@ pub fn collect_function_level_profiling_info(
                             | StarknetConcreteLibfunc::SendMessageToL1(_)
                             | StarknetConcreteLibfunc::StorageRead(_)
                             | StarknetConcreteLibfunc::StorageWrite(_)
-                            | StarknetConcreteLibfunc::Sha256ProcessBlock(_) => libfunc,
+                            | StarknetConcreteLibfunc::Sha256ProcessBlock(_)
+                            | StarknetConcreteLibfunc::MetaTxV0(_) => libfunc,
                             _ => {
                                 if in_syscall_idx.is_some() {
                                     in_syscall_idx = None;
@@ -297,45 +312,42 @@ pub fn collect_function_level_profiling_info(
 
                             // we do not have builtins vm resources costs, we only include them when tracking sierra gas
                             if sierra_gas_tracking {
-                                let libfunc_cost =
-                                    core_libfunc_cost(libfunc.unwrap(), &cost_info_provider);
+                                let cost_vector = core_libfunc_cost(
+                                    &precost_info,
+                                    &sierra_statement_idx,
+                                    libfunc.unwrap(),
+                                    &profiler_info_provider,
+                                );
 
-                                for branch_cost in &libfunc_cost {
-                                    if let BranchCost::Regular {
-                                        const_cost,
-                                        pre_cost,
-                                    } = branch_cost
+                                for branch_cost_map in &cost_vector {
+                                    let branch_cost = CostEntry::from_map(branch_cost_map);
+
+                                    // determine if we are already tracking this specific invocation (libfunc)
+                                    // we use sierra gas estimated by `core_libfunc_cost` function to do this
+                                    if branch_cost.konst == 100
+                                        || branch_cost.konst <= libfunc_appearance_tracker
                                     {
-                                        // determine if we are already tracking this specific invocation (libfunc)
-                                        // we use steps estimated by `core_libfunc_cost` function to do this
-                                        if const_cost.steps == 1
-                                            || const_cost.steps <= libfunc_appearance_tracker
-                                        {
-                                            // if a given invocation "costs" some builtins, sum them
-                                            let post_cost = sum_builtins_cost(
-                                                const_cost,
-                                                pre_cost,
-                                                versioned_constants,
-                                                builtins_with_cost,
-                                            );
+                                        // if a given invocation "costs" some builtins, sum them
+                                        let post_cost =
+                                            sum_builtins_cost(&branch_cost, versioned_constants);
 
-                                            // add builtin cost (resources) to current function in stack
-                                            *functions_stack_traces
-                                                .entry(libfunc_call_stack.clone().into())
-                                                .or_default() +=
-                                                ChargedResources {
-                                                    steps: Default::default(),
-                                                    sierra_gas_consumed: SierraGasConsumed(
-                                                        usize::try_from(post_cost).expect("Overflow while converting post_cost to usize"),
-                                                    ),
-                                                };
+                                        // add builtin cost (resources) to current function in stack
+                                        *functions_stack_traces
+                                            .entry(libfunc_call_stack.clone().into())
+                                            .or_default() += ChargedResources {
+                                            steps: Default::default(),
+                                            sierra_gas_consumed: SierraGasConsumed(
+                                                usize::try_from(post_cost).expect(
+                                                    "Overflow while converting post_cost to usize",
+                                                ),
+                                            ),
+                                        };
 
-                                            libfunc_appearance_tracker = 1;
-                                        // if an invocation takes more than 1 step, we skip getting its cost for subsequent
-                                        // appearances in stack, so we do not wrongly add the resources multiple times
-                                        } else if const_cost.steps > libfunc_appearance_tracker {
-                                            libfunc_appearance_tracker += 1;
-                                        }
+                                        libfunc_appearance_tracker = 100;
+                                    // if an invocation takes more than 1 step (100 sierra gas), we skip getting its cost for subsequent
+                                    // appearances in stack, so we do not wrongly add the resources multiple times
+                                    } else if branch_cost.konst > libfunc_appearance_tracker {
+                                        libfunc_appearance_tracker += 100;
                                     }
                                 }
                             }
@@ -403,48 +415,21 @@ fn build_current_call_stack(
     }
 }
 
-fn sum_builtins_cost(
-    const_cost: &ConstCost,
-    pre_cost: &PreCost,
-    versioned_constants: &VersionedConstants,
-    builtins_with_cost: [CostTokenType; 6],
-) -> u64 {
-    let mut post_cost: u64 = u64::try_from(const_cost.range_checks)
-        .expect("Failed to convert const_cost to u64")
-        * versioned_constants
-            .os_constants
-            .builtin_gas_costs
-            .range_check;
-    post_cost += u64::try_from(const_cost.range_checks96)
-        .expect("Failed to convert const_cost to u64")
-        * versioned_constants
-            .os_constants
-            .builtin_gas_costs
-            .range_check96;
+fn sum_builtins_cost(branch_cost: &CostEntry, versioned_constants: &VersionedConstants) -> u64 {
+    let mut post_cost: u64 = u64::default();
 
-    for builtin in &builtins_with_cost {
-        if let Some(value) = pre_cost.0.get(builtin) {
-            let builtin_cost = match builtin {
-                CostTokenType::Bitwise => {
-                    versioned_constants.os_constants.builtin_gas_costs.bitwise
-                }
-                CostTokenType::Pedersen => {
-                    versioned_constants.os_constants.builtin_gas_costs.pedersen
-                }
-                CostTokenType::Poseidon => {
-                    versioned_constants.os_constants.builtin_gas_costs.poseidon
-                }
-                CostTokenType::EcOp => versioned_constants.os_constants.builtin_gas_costs.ecop,
-                CostTokenType::AddMod => versioned_constants.os_constants.builtin_gas_costs.add_mod,
-                CostTokenType::MulMod => versioned_constants.os_constants.builtin_gas_costs.mul_mod,
-                _ => {
-                    panic!("Unknown builtin: {builtin:?}")
-                }
-            };
-            post_cost += u64::try_from(*value)
-                .expect("Failed to convert builtin count value to u64")
-                * builtin_cost;
-        }
+    for (token, cost) in branch_cost.iter() {
+        let cost = u64::try_from(cost.max(0)).expect("Cost must be non-negative after clamping");
+        let builtin_cost = match token {
+            CostTokenType::Pedersen => versioned_constants.os_constants.builtin_gas_costs.pedersen,
+            CostTokenType::Poseidon => versioned_constants.os_constants.builtin_gas_costs.poseidon,
+            CostTokenType::Bitwise => versioned_constants.os_constants.builtin_gas_costs.bitwise,
+            CostTokenType::EcOp => versioned_constants.os_constants.builtin_gas_costs.ecop,
+            CostTokenType::AddMod => versioned_constants.os_constants.builtin_gas_costs.add_mod,
+            CostTokenType::MulMod => versioned_constants.os_constants.builtin_gas_costs.mul_mod,
+            _ => continue,
+        };
+        post_cost += builtin_cost * cost;
     }
     post_cost
 }

--- a/crates/cairo-profiler/src/trace_reader/function_trace_builder/cost.rs
+++ b/crates/cairo-profiler/src/trace_reader/function_trace_builder/cost.rs
@@ -1,0 +1,99 @@
+use cairo_lang_sierra::extensions::circuit::CircuitInfo;
+use cairo_lang_sierra::extensions::gas::CostTokenType;
+use cairo_lang_sierra::ids::ConcreteTypeId;
+use cairo_lang_sierra::program::StatementIdx;
+use cairo_lang_sierra_ap_change::core_libfunc_ap_change::InvocationApChangeInfoProvider;
+use cairo_lang_sierra_gas::core_libfunc_cost::InvocationCostInfoProvider;
+use cairo_lang_sierra_to_casm::circuit::CircuitsInfo;
+use cairo_lang_sierra_to_casm::metadata::Metadata;
+use cairo_lang_sierra_type_size::TypeSizeMap;
+use cairo_lang_utils::casts::IntoOrPanic;
+use cairo_lang_utils::ordered_hash_map::OrderedHashMap;
+use serde::{Deserialize, Serialize};
+
+pub struct ProfilerInvocationInfo<'a> {
+    pub type_sizes: &'a TypeSizeMap,
+    pub circuits_info: &'a CircuitsInfo,
+    pub metadata: &'a Metadata,
+    pub idx: StatementIdx,
+}
+
+impl InvocationCostInfoProvider for ProfilerInvocationInfo<'_> {
+    fn type_size(&self, ty: &ConcreteTypeId) -> usize {
+        self.type_sizes[ty].into_or_panic()
+    }
+
+    fn token_usages(&self, token_type: CostTokenType) -> usize {
+        InvocationApChangeInfoProvider::token_usages(self, token_type)
+    }
+
+    fn ap_change_var_value(&self) -> usize {
+        self.metadata
+            .ap_change_info
+            .variable_values
+            .get(&self.idx)
+            .copied()
+            .unwrap_or_default()
+    }
+
+    fn circuit_info(&self, ty: &ConcreteTypeId) -> &CircuitInfo {
+        self.circuits_info.circuits.get(ty).unwrap()
+    }
+}
+
+impl InvocationApChangeInfoProvider for ProfilerInvocationInfo<'_> {
+    fn type_size(&self, ty: &ConcreteTypeId) -> usize {
+        self.type_sizes[ty].into_or_panic()
+    }
+
+    fn token_usages(&self, token_type: CostTokenType) -> usize {
+        usize::try_from(
+            self.metadata
+                .gas_info
+                .variable_values
+                .get(&(self.idx, token_type))
+                .copied()
+                .unwrap_or(0),
+        )
+        .unwrap()
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct CostEntry {
+    pub pedersen: i64,
+    pub poseidon: i64,
+    pub bitwise: i64,
+    pub ec_op: i64,
+    pub add_mod: i64,
+    pub mul_mod: i64,
+    #[serde(rename = "const")]
+    pub konst: i64,
+}
+
+impl CostEntry {
+    pub fn from_map(map: &OrderedHashMap<CostTokenType, i64>) -> Self {
+        Self {
+            pedersen: *map.get(&CostTokenType::Pedersen).unwrap_or(&0),
+            poseidon: *map.get(&CostTokenType::Poseidon).unwrap_or(&0),
+            bitwise: *map.get(&CostTokenType::Bitwise).unwrap_or(&0),
+            ec_op: *map.get(&CostTokenType::EcOp).unwrap_or(&0),
+            add_mod: *map.get(&CostTokenType::AddMod).unwrap_or(&0),
+            mul_mod: *map.get(&CostTokenType::MulMod).unwrap_or(&0),
+            konst: *map.get(&CostTokenType::Const).unwrap_or(&0),
+        }
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = (CostTokenType, i64)> + '_ {
+        [
+            (CostTokenType::Const, self.konst),
+            (CostTokenType::Bitwise, self.bitwise),
+            (CostTokenType::Pedersen, self.pedersen),
+            (CostTokenType::Poseidon, self.poseidon),
+            (CostTokenType::EcOp, self.ec_op),
+            (CostTokenType::AddMod, self.add_mod),
+            (CostTokenType::MulMod, self.mul_mod),
+        ]
+        .into_iter()
+    }
+}

--- a/crates/cairo-profiler/tests/data/missing_syscall_versioned_constants.json
+++ b/crates/cairo-profiler/tests/data/missing_syscall_versioned_constants.json
@@ -291,7 +291,7 @@
             "GetClassHashAt": {
                 "n_steps": 0,
                 "builtin_instance_counter": {},
-                "n_memory_holes": 0,
+                "n_memory_holes": 0
             },
             "MetaTxV0": {
                 "n_steps": 0,

--- a/crates/cairo-profiler/tests/e2e.rs
+++ b/crates/cairo-profiler/tests/e2e.rs
@@ -204,26 +204,26 @@ fn view_steps() {
         .stdout_eq(indoc!(
             r#"
 
-            Showing nodes accounting for 1463 steps, 100.00% of 1463 steps total
+            Showing nodes accounting for 1503 steps, 100.00% of 1503 steps total
             Showing top 15 nodes out of 15
             
                   flat |  flat% |    sum% |        cum |    cum% |  
             -----------+--------+---------+------------+---------+--------------------------------------------------------------------------------------------------------------
-             866 steps | 59.19% |  59.19% |  866 steps |  59.19% | "CallContract" 
-             102 steps |  6.97% |  66.17% |  179 steps |  12.24% | "core::result::ResultSerde::deserialize" 
-              87 steps |  5.95% |  72.11% |   87 steps |   5.95% | "StorageRead" 
-              87 steps |  5.95% |  78.06% |   87 steps |   5.95% | "snforge_std::cheatcode::execute_cheatcode" 
-              64 steps |  4.37% |  82.43% | 1314 steps |  89.82% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value_return_wrapper" 
-              39 steps |  2.67% |  85.10% |   39 steps |   2.67% | "core::array::SpanFelt252Serde::deserialize" 
-              38 steps |  2.60% |  87.70% |   38 steps |   2.60% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
-              37 steps |  2.53% |  90.23% |  124 steps |   8.48% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
-              34 steps |  2.32% |  92.55% |  183 steps |  12.51% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
-              34 steps |  2.32% |  94.87% |  150 steps |  10.25% | "snforge_std::cheatcodes::contract_class::declare" 
-              28 steps |  1.91% |  96.79% |   28 steps |   1.91% | "core::array::serialize_array_helper" 
-              23 steps |  1.57% |  98.36% | 1337 steps |  91.39% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
-              22 steps |  1.50% |  99.86% |   51 steps |   3.49% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
-               1 steps |  0.07% |  99.93% |  125 steps |   8.54% | "Contract: HelloStarknet\nFunction: get_balance\n" 
-               1 steps |  0.07% | 100.00% | 1463 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
+             903 steps | 60.08% |  60.08% |  903 steps |  60.08% | "CallContract" 
+             102 steps |  6.79% |  66.87% |  179 steps |  11.91% | "core::result::ResultSerde::deserialize" 
+              90 steps |  5.99% |  72.85% |   90 steps |   5.99% | "StorageRead" 
+              87 steps |  5.79% |  78.64% |   87 steps |   5.79% | "snforge_std::cheatcode::execute_cheatcode" 
+              64 steps |  4.26% |  82.90% | 1351 steps |  89.89% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value_return_wrapper" 
+              39 steps |  2.59% |  85.50% |   39 steps |   2.59% | "core::array::SpanFelt252Serde::deserialize" 
+              38 steps |  2.53% |  88.02% |   38 steps |   2.53% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
+              37 steps |  2.46% |  90.49% |  127 steps |   8.45% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
+              34 steps |  2.26% |  92.75% |  183 steps |  12.18% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
+              34 steps |  2.26% |  95.01% |  150 steps |   9.98% | "snforge_std::cheatcodes::contract_class::declare" 
+              28 steps |  1.86% |  96.87% |   28 steps |   1.86% | "core::array::serialize_array_helper" 
+              23 steps |  1.53% |  98.40% | 1374 steps |  91.42% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
+              22 steps |  1.46% |  99.87% |   51 steps |   3.39% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
+               1 steps |  0.07% |  99.93% |  128 steps |   8.52% | "Contract: HelloStarknet\nFunction: get_balance\n" 
+               1 steps |  0.07% | 100.00% | 1503 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
             "#
         ));
 }
@@ -255,14 +255,14 @@ fn view_range_check_builtin() {
         .stdout_eq(indoc!(
             r#"
 
-            Showing nodes accounting for 38 range check builtin, 97.44% of 39 range check builtin total
+            Showing nodes accounting for 41 range check builtin, 97.62% of 42 range check builtin total
             Showing top 3 nodes out of 15
             
                                flat |  flat% |   sum% |                    cum |    cum% |  
             ------------------------+--------+--------+------------------------+---------+-----------------------------------------------------------------------
-             21 range check builtin | 53.85% | 53.85% | 39 range check builtin | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
-             15 range check builtin | 38.46% | 92.31% | 15 range check builtin |  38.46% | "CallContract" 
-              2 range check builtin |  5.13% | 97.44% |  3 range check builtin |   7.69% | "Contract: HelloStarknet\nFunction: get_balance\n" 
+             21 range check builtin | 50.00% | 50.00% | 42 range check builtin | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
+             18 range check builtin | 42.86% | 92.86% | 18 range check builtin |  42.86% | "CallContract" 
+              2 range check builtin |  4.76% | 97.62% |  3 range check builtin |   7.14% | "Contract: HelloStarknet\nFunction: get_balance\n" 
             "#
         ));
 }
@@ -344,23 +344,23 @@ fn view_hide_in_view() {
             Active filter:
             hide=core
 
-            Showing nodes accounting for 1463 steps, 100.00% of 1463 steps total
+            Showing nodes accounting for 1503 steps, 100.00% of 1503 steps total
             Showing top 12 nodes out of 12
 
                   flat |  flat% |    sum% |        cum |    cum% |  
             -----------+--------+---------+------------+---------+--------------------------------------------------------------------------------------------------------------
-             866 steps | 59.19% |  59.19% |  866 steps |  59.19% | "CallContract" 
-             154 steps | 10.53% |  69.72% |  183 steps |  12.51% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
-              87 steps |  5.95% |  75.67% |   87 steps |   5.95% | "StorageRead" 
-              87 steps |  5.95% |  81.61% |   87 steps |   5.95% | "snforge_std::cheatcode::execute_cheatcode" 
-              83 steps |  5.67% |  87.29% |  150 steps |  10.25% | "snforge_std::cheatcodes::contract_class::declare" 
-              64 steps |  4.37% |  91.66% | 1314 steps |  89.82% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value_return_wrapper" 
-              38 steps |  2.60% |  94.26% |   38 steps |   2.60% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
-              37 steps |  2.53% |  96.79% |  124 steps |   8.48% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
-              23 steps |  1.57% |  98.36% | 1337 steps |  91.39% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
-              22 steps |  1.50% |  99.86% |   51 steps |   3.49% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
-               1 steps |  0.07% |  99.93% |  125 steps |   8.54% | "Contract: HelloStarknet\nFunction: get_balance\n" 
-               1 steps |  0.07% | 100.00% | 1463 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
+             903 steps | 60.08% |  60.08% |  903 steps |  60.08% | "CallContract" 
+             154 steps | 10.25% |  70.33% |  183 steps |  12.18% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
+              90 steps |  5.99% |  76.31% |   90 steps |   5.99% | "StorageRead" 
+              87 steps |  5.79% |  82.10% |   87 steps |   5.79% | "snforge_std::cheatcode::execute_cheatcode" 
+              83 steps |  5.52% |  87.62% |  150 steps |   9.98% | "snforge_std::cheatcodes::contract_class::declare" 
+              64 steps |  4.26% |  91.88% | 1351 steps |  89.89% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value_return_wrapper" 
+              38 steps |  2.53% |  94.41% |   38 steps |   2.53% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
+              37 steps |  2.46% |  96.87% |  127 steps |   8.45% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
+              23 steps |  1.53% |  98.40% | 1374 steps |  91.42% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
+              22 steps |  1.46% |  99.87% |   51 steps |   3.39% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
+               1 steps |  0.07% |  99.93% |  128 steps |   8.52% | "Contract: HelloStarknet\nFunction: get_balance\n" 
+               1 steps |  0.07% | 100.00% | 1503 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
             "#
     );
 
@@ -410,23 +410,23 @@ fn view_hide_in_build() {
             Active filter:
             hide=core::*
 
-            Showing nodes accounting for 1463 steps, 100.00% of 1463 steps total
+            Showing nodes accounting for 1503 steps, 100.00% of 1503 steps total
             Showing top 12 nodes out of 12
 
                   flat |  flat% |    sum% |        cum |    cum% |  
             -----------+--------+---------+------------+---------+--------------------------------------------------------------------------------------------------------------
-             866 steps | 59.19% |  59.19% |  866 steps |  59.19% | "CallContract" 
-             154 steps | 10.53% |  69.72% |  183 steps |  12.51% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
-              87 steps |  5.95% |  75.67% |   87 steps |   5.95% | "StorageRead" 
-              87 steps |  5.95% |  81.61% |   87 steps |   5.95% | "snforge_std::cheatcode::execute_cheatcode" 
-              83 steps |  5.67% |  87.29% |  150 steps |  10.25% | "snforge_std::cheatcodes::contract_class::declare" 
-              64 steps |  4.37% |  91.66% | 1314 steps |  89.82% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value_return_wrapper" 
-              38 steps |  2.60% |  94.26% |   38 steps |   2.60% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
-              37 steps |  2.53% |  96.79% |  124 steps |   8.48% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
-              23 steps |  1.57% |  98.36% | 1337 steps |  91.39% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
-              22 steps |  1.50% |  99.86% |   51 steps |   3.49% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
-               1 steps |  0.07% |  99.93% |  125 steps |   8.54% | "Contract: HelloStarknet\nFunction: get_balance\n" 
-               1 steps |  0.07% | 100.00% | 1463 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
+             903 steps | 60.08% |  60.08% |  903 steps |  60.08% | "CallContract" 
+             154 steps | 10.25% |  70.33% |  183 steps |  12.18% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
+              90 steps |  5.99% |  76.31% |   90 steps |   5.99% | "StorageRead" 
+              87 steps |  5.79% |  82.10% |   87 steps |   5.79% | "snforge_std::cheatcode::execute_cheatcode" 
+              83 steps |  5.52% |  87.62% |  150 steps |   9.98% | "snforge_std::cheatcodes::contract_class::declare" 
+              64 steps |  4.26% |  91.88% | 1351 steps |  89.89% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value_return_wrapper" 
+              38 steps |  2.53% |  94.41% |   38 steps |   2.53% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
+              37 steps |  2.46% |  96.87% |  127 steps |   8.45% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
+              23 steps |  1.53% |  98.40% | 1374 steps |  91.42% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
+              22 steps |  1.46% |  99.87% |   51 steps |   3.39% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
+               1 steps |  0.07% |  99.93% |  128 steps |   8.52% | "Contract: HelloStarknet\nFunction: get_balance\n" 
+               1 steps |  0.07% | 100.00% | 1503 steps | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
             "#
     );
 
@@ -482,26 +482,26 @@ fn view_sierra_gas() {
         .stdout_eq(indoc!(
             r#"
 
-            Showing nodes accounting for 148525 sierra gas, 100.00% of 148525 sierra gas total
+            Showing nodes accounting for 151388 sierra gas, 100.00% of 151388 sierra gas total
             Showing top 15 nodes out of 15
             
                          flat |  flat% |    sum% |               cum |    cum% |  
             ------------------+--------+---------+-------------------+---------+--------------------------------------------------------------------------------------------------------------
-             86685 sierra gas | 58.36% |  58.36% |  86685 sierra gas |  58.36% | "CallContract" 
-             10200 sierra gas |  6.87% |  65.23% |  18320 sierra gas |  12.33% | "core::result::ResultSerde::deserialize" 
-             10000 sierra gas |  6.73% |  71.96% |  10000 sierra gas |   6.73% | "StorageRead" 
-              9120 sierra gas |  6.14% |  78.10% |   9120 sierra gas |   6.14% | "snforge_std::cheatcode::execute_cheatcode" 
-              6400 sierra gas |  4.31% |  82.41% | 132325 sierra gas |  89.09% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value_return_wrapper" 
-              4320 sierra gas |  2.91% |  85.32% |   4320 sierra gas |   2.91% | "core::array::SpanFelt252Serde::deserialize" 
-              3800 sierra gas |  2.56% |  87.88% |   3800 sierra gas |   2.56% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
-              3700 sierra gas |  2.49% |  90.37% |  13700 sierra gas |   9.22% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
-              3400 sierra gas |  2.29% |  92.66% |  18860 sierra gas |  12.70% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
-              3400 sierra gas |  2.29% |  94.95% |  15140 sierra gas |  10.19% | "snforge_std::cheatcodes::contract_class::declare" 
-              2800 sierra gas |  1.89% |  96.84% |   2800 sierra gas |   1.89% | "core::array::serialize_array_helper" 
-              2300 sierra gas |  1.55% |  98.38% | 134625 sierra gas |  90.64% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
-              2200 sierra gas |  1.48% |  99.87% |   5240 sierra gas |   3.53% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
-               100 sierra gas |  0.07% |  99.93% |  13800 sierra gas |   9.29% | "Contract: HelloStarknet\nFunction: get_balance\n" 
-               100 sierra gas |  0.07% | 100.00% | 148525 sierra gas | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
+             90388 sierra gas | 59.71% |  59.71% |  90388 sierra gas |  59.71% | "CallContract" 
+             10200 sierra gas |  6.74% |  66.44% |  17900 sierra gas |  11.82% | "core::result::ResultSerde::deserialize" 
+             10000 sierra gas |  6.61% |  73.05% |  10000 sierra gas |   6.61% | "StorageRead" 
+              8700 sierra gas |  5.75% |  78.80% |   8700 sierra gas |   5.75% | "snforge_std::cheatcode::execute_cheatcode" 
+              6400 sierra gas |  4.23% |  83.02% | 135188 sierra gas |  89.30% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value_return_wrapper" 
+              3900 sierra gas |  2.58% |  85.60% |   3900 sierra gas |   2.58% | "core::array::SpanFelt252Serde::deserialize" 
+              3800 sierra gas |  2.51% |  88.11% |   3800 sierra gas |   2.51% | "snforge_std::cheatcodes::contract_class::DeclareResultSerde::deserialize" 
+              3700 sierra gas |  2.44% |  90.55% |  13700 sierra gas |   9.05% | "balance_simple::HelloStarknet::__wrapper__HelloStarknetImpl__get_balance" 
+              3400 sierra gas |  2.25% |  92.80% |  18300 sierra gas |  12.09% | "snforge_std::cheatcodes::contract_class::ContractClassImpl::deploy" 
+              3400 sierra gas |  2.25% |  95.05% |  15000 sierra gas |   9.91% | "snforge_std::cheatcodes::contract_class::declare" 
+              2800 sierra gas |  1.85% |  96.90% |   2800 sierra gas |   1.85% | "core::array::serialize_array_helper" 
+              2300 sierra gas |  1.52% |  98.41% | 137488 sierra gas |  90.82% | "balance_simple_integrationtest::test_contract::test_cannot_increase_balance_with_zero_value" 
+              2200 sierra gas |  1.45% |  99.87% |   5100 sierra gas |   3.37% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
+               100 sierra gas |  0.07% |  99.93% |  13800 sierra gas |   9.12% | "Contract: HelloStarknet\nFunction: get_balance\n" 
+               100 sierra gas |  0.07% | 100.00% | 151388 sierra gas | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
             "#
         ));
 }
@@ -541,15 +541,15 @@ fn view_builtins_factored_in() {
         .stdout_eq(indoc!(
             r#"
             
-            Showing nodes accounting for 13590 sierra gas, 100.00% of 13590 sierra gas total
+            Showing nodes accounting for 13450 sierra gas, 100.00% of 13450 sierra gas total
             Showing top 4 nodes out of 4
             
                         flat |  flat% |    sum% |              cum |    cum% |  
             -----------------+--------+---------+------------------+---------+-----------------------------------------------------------------------
-             8250 sierra gas | 60.71% |  60.71% | 13490 sierra gas |  99.26% | "builtins_simple::tests::pedersen_cost" 
-             3040 sierra gas | 22.37% |  83.08% |  3040 sierra gas |  22.37% | "snforge_std::cheatcode::execute_cheatcode" 
-             2200 sierra gas | 16.19% |  99.26% |  5240 sierra gas |  38.56% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
-              100 sierra gas |  0.74% | 100.00% | 13590 sierra gas | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
+             8250 sierra gas | 61.34% |  61.34% | 13350 sierra gas |  99.26% | "builtins_simple::tests::pedersen_cost" 
+             2900 sierra gas | 21.56% |  82.90% |  2900 sierra gas |  21.56% | "snforge_std::cheatcode::execute_cheatcode" 
+             2200 sierra gas | 16.36% |  99.26% |  5100 sierra gas |  37.92% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
+              100 sierra gas |  0.74% | 100.00% | 13450 sierra gas | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
             "#
         ));
 }
@@ -590,28 +590,28 @@ fn view_all_libfuncs() {
         .stdout_eq(indoc!(
             r#"
             
-            Showing nodes accounting for 10123 sierra gas, 100.00% of 10123 sierra gas total
+            Showing nodes accounting for 9983 sierra gas, 100.00% of 9983 sierra gas total
             Showing top 17 nodes out of 17
             
-                        flat |  flat% |    sum% |              cum |    cum% |  
-            -----------------+--------+---------+------------------+---------+-----------------------------------------------------------------------
-             5200 sierra gas | 51.37% |  51.37% |  5200 sierra gas |  51.37% | "store_temp" 
-              783 sierra gas |  7.73% |  59.10% |   783 sierra gas |   7.73% | "u8_bitwise" 
-              570 sierra gas |  5.63% |  64.73% |   570 sierra gas |   5.63% | "array_slice" 
-              500 sierra gas |  4.94% |  69.67% |   500 sierra gas |   4.94% | "withdraw_gas_all" 
-              400 sierra gas |  3.95% |  73.62% |   400 sierra gas |   3.95% | "array_snapshot_pop_front" 
-              370 sierra gas |  3.66% |  77.28% |   370 sierra gas |   3.66% | "u32_overflowing_sub" 
-              300 sierra gas |  2.96% |  80.24% |   300 sierra gas |   2.96% | "enum_match" 
-              300 sierra gas |  2.96% |  83.21% |   300 sierra gas |   2.96% | "felt252_is_zero" 
-              300 sierra gas |  2.96% |  86.17% |   300 sierra gas |   2.96% | "withdraw_gas" 
-              200 sierra gas |  1.98% |  88.15% |   200 sierra gas |   1.98% | "array_new" 
-              200 sierra gas |  1.98% |  90.12% | 10023 sierra gas |  99.01% | "builtins_simple::tests::bitwise_cost" 
-              200 sierra gas |  1.98% |  92.10% |   200 sierra gas |   1.98% | "get_builtin_costs" 
-              200 sierra gas |  1.98% |  94.07% |   200 sierra gas |   1.98% | "jump" 
-              200 sierra gas |  1.98% |  96.05% |  3040 sierra gas |  30.03% | "snforge_std::cheatcode::execute_cheatcode" 
-              200 sierra gas |  1.98% |  98.02% |  5240 sierra gas |  51.76% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
-              100 sierra gas |  0.99% |  99.01% | 10123 sierra gas | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
-              100 sierra gas |  0.99% | 100.00% |   100 sierra gas |   0.99% | "bool_not_impl" 
+                        flat |  flat% |    sum% |             cum |    cum% |  
+            -----------------+--------+---------+-----------------+---------+-----------------------------------------------------------------------
+             5200 sierra gas | 52.09% |  52.09% | 5200 sierra gas |  52.09% | "store_temp" 
+              783 sierra gas |  7.84% |  59.93% |  783 sierra gas |   7.84% | "u8_bitwise" 
+              500 sierra gas |  5.01% |  64.94% |  500 sierra gas |   5.01% | "array_slice" 
+              500 sierra gas |  5.01% |  69.95% |  500 sierra gas |   5.01% | "withdraw_gas_all" 
+              400 sierra gas |  4.01% |  73.96% |  400 sierra gas |   4.01% | "array_snapshot_pop_front" 
+              300 sierra gas |  3.01% |  76.96% |  300 sierra gas |   3.01% | "enum_match" 
+              300 sierra gas |  3.01% |  79.97% |  300 sierra gas |   3.01% | "felt252_is_zero" 
+              300 sierra gas |  3.01% |  82.97% |  300 sierra gas |   3.01% | "u32_overflowing_sub" 
+              300 sierra gas |  3.01% |  85.98% |  300 sierra gas |   3.01% | "withdraw_gas" 
+              200 sierra gas |  2.00% |  87.98% |  200 sierra gas |   2.00% | "array_new" 
+              200 sierra gas |  2.00% |  89.98% | 9883 sierra gas |  99.00% | "builtins_simple::tests::bitwise_cost" 
+              200 sierra gas |  2.00% |  91.99% |  200 sierra gas |   2.00% | "get_builtin_costs" 
+              200 sierra gas |  2.00% |  93.99% |  200 sierra gas |   2.00% | "jump" 
+              200 sierra gas |  2.00% |  95.99% | 2900 sierra gas |  29.05% | "snforge_std::cheatcode::execute_cheatcode" 
+              200 sierra gas |  2.00% |  98.00% | 5100 sierra gas |  51.09% | "snforge_std::cheatcode::execute_cheatcode_and_deserialize" 
+              100 sierra gas |  1.00% |  99.00% | 9983 sierra gas | 100.00% | "Contract: SNFORGE_TEST_CODE\nFunction: SNFORGE_TEST_CODE_FUNCTION\n" 
+              100 sierra gas |  1.00% | 100.00% |  100 sierra gas |   1.00% | "bool_not_impl" 
             "#
         ));
 }


### PR DESCRIPTION
Closes #168 

## Introduced changes

This PR is a part of a bigger stack with an end goal to add support for calldata factor.

The PRs are:
-- Bump versioned constants to 0.14.1 (https://github.com/software-mansion/cairo-profiler/pull/197)
--> Bump cairo to 2.12 (rc), use new cairo cost estimation interface (This PR) 
-- Refactor `function_trace_builder` function (https://github.com/software-mansion/cairo-profiler/pull/199)
-- Display contract entrypoints as called from functions (https://github.com/software-mansion/cairo-profiler/pull/200)
-- Add tests for new tree structure (https://github.com/software-mansion/cairo-profiler/pull/201)
-- Factor in calldata factor for scaled syscalls (https://github.com/software-mansion/cairo-profiler/pull/202)
-- Add tests for calldata factor (https://github.com/software-mansion/cairo-profiler/pull/203)
-- Bump cairo and cairo annotations to their latest stable versions (https://github.com/software-mansion/cairo-profiler/pull/206)

## Checklist

- [X] Linked relevant issue
- [ ] Updated relevant documentation (README.md)
- [X] Added relevant tests
- [X] Performed self-review of the code
- [X] Added changes to `CHANGELOG.md`
