### PR TITLE
Bump cairo and cairo-annotations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -155,6 +155,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,8 +205,9 @@ checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "cairo-annotations"
-version = "0.5.0-rc.2"
-source = "git+https://github.com/software-mansion/cairo-annotations.git?branch=szymczyk%2Fcalldata-length#f0932418e8a8017bcab7b086d826333864bfc597"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a46c8836608a014faf85fb2e5b99de2de5e7a6da18ff72fb6d3451f3812838e4"
 dependencies = [
  "cairo-lang-sierra",
  "cairo-lang-sierra-to-casm",
@@ -632,6 +642,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -1613,9 +1624,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.142"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "030fedb782600dcbd6f02d479bf0d817ac3bb40d644745b769d6a96bc3afc5a7"
 dependencies = [
  "itoa",
  "memchr",
@@ -1720,10 +1731,12 @@ checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "starknet-types-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4037bcb26ce7c508448d221e570d075196fd4f6912ae6380981098937af9522a"
+checksum = "87af771d7f577931913089f9ca9a9f85d8a6238d59b2977f4c383d133c8abd3b"
 dependencies = [
+ "blake2",
+ "digest",
  "lambdaworks-crypto",
  "lambdaworks-math",
  "lazy_static",
@@ -1771,6 +1784,12 @@ dependencies = [
  "rustversion",
  "syn 2.0.103",
 ]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,18 +27,15 @@ prost-build = { version = "0.14" }
 test-case = "3.3.1"
 itertools = "0.14.0"
 indoc = "2"
-cairo-annotations = "0.5.0-rc.2"
+cairo-annotations = "0.5.0"
 prettytable-rs = "0.10.0"
 regex = "1.11.1"
 console = "0.16.0"
 
-cairo-lang-sierra = "2.12.0-rc.0"
-cairo-lang-sierra-to-casm = "2.12.0-rc.0"
-cairo-lang-starknet-classes = "2.12.0-rc.0"
-cairo-lang-sierra-gas = "2.12.0-rc.0"
-cairo-lang-sierra-type-size = "2.12.0-rc.0"
-cairo-lang-sierra-ap-change = "2.12.0-rc.0"
-cairo-lang-utils = "2.12.0-rc.0"
-
-[patch.crates-io]
-cairo-annotations = { git = "https://github.com/software-mansion/cairo-annotations.git", branch = "szymczyk/calldata-length" }
+cairo-lang-sierra = "2.12.0"
+cairo-lang-sierra-to-casm = "2.12.0"
+cairo-lang-starknet-classes = "2.12.0"
+cairo-lang-sierra-gas = "2.12.0"
+cairo-lang-sierra-type-size = "2.12.0"
+cairo-lang-sierra-ap-change = "2.12.0"
+cairo-lang-utils = "2.12.0"

--- a/crates/cairo-profiler/Cargo.toml
+++ b/crates/cairo-profiler/Cargo.toml
@@ -23,6 +23,7 @@ cairo-annotations.workspace = true
 prettytable-rs.workspace = true
 regex.workspace = true
 console.workspace = true
+indexmap.workspace = true
 
 cairo-lang-sierra.workspace = true
 cairo-lang-sierra-to-casm.workspace = true

--- a/crates/cairo-profiler/Cargo.toml
+++ b/crates/cairo-profiler/Cargo.toml
@@ -23,7 +23,6 @@ cairo-annotations.workspace = true
 prettytable-rs.workspace = true
 regex.workspace = true
 console.workspace = true
-indexmap.workspace = true
 
 cairo-lang-sierra.workspace = true
 cairo-lang-sierra-to-casm.workspace = true


### PR DESCRIPTION
Closes #204 

## Introduced changes

This PR is a part of a bigger stack with an end goal to add support for calldata factor.

The PRs are:
-- Bump versioned constants to 0.14.1 (https://github.com/software-mansion/cairo-profiler/pull/197)
-- Bump cairo to 2.12 (rc), use new cairo cost estimation interface (https://github.com/software-mansion/cairo-profiler/pull/198) 
-- Refactor `function_trace_builder` function (https://github.com/software-mansion/cairo-profiler/pull/199)
-- Display contract entrypoints as called from functions (https://github.com/software-mansion/cairo-profiler/pull/200)
-- Add tests for new tree structure (https://github.com/software-mansion/cairo-profiler/pull/201)
-- Factor in calldata factor for scaled syscalls (https://github.com/software-mansion/cairo-profiler/pull/202)
-- Add tests for calldata factor (https://github.com/software-mansion/cairo-profiler/pull/203)
--> Bump cairo and cairo annotations to their latest stable versions (This PR)

## Checklist

- [X] Linked relevant issue
- [ ] Updated relevant documentation (README.md)
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
