### PR TITLE
Include archival data gas costs in versioned constants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -396,6 +396,7 @@ dependencies = [
  "flate2",
  "indoc",
  "itertools",
+ "num-rational",
  "prettytable-rs",
  "project-root",
  "prost",
@@ -1156,6 +1157,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ cairo-annotations = "0.5.0"
 prettytable-rs = "0.10.0"
 regex = "1.11.1"
 console = "0.16.0"
+num-rational = "0.4.2"
 
 cairo-lang-sierra = "2.12.0"
 cairo-lang-sierra-to-casm = "2.12.0"

--- a/crates/cairo-profiler/Cargo.toml
+++ b/crates/cairo-profiler/Cargo.toml
@@ -23,6 +23,7 @@ cairo-annotations.workspace = true
 prettytable-rs.workspace = true
 regex.workspace = true
 console.workspace = true
+num-rational = { workspace = true, features = ["serde"] }
 
 cairo-lang-sierra.workspace = true
 cairo-lang-sierra-to-casm.workspace = true

--- a/crates/cairo-profiler/tests/data/invalid_versioned_constants.json
+++ b/crates/cairo-profiler/tests/data/invalid_versioned_constants.json
@@ -1,4 +1,18 @@
 {
+    "archival_data_gas_costs": {
+        "gas_per_data_felt": [
+            5120,
+            1
+        ],
+        "event_key_factor": [
+            2,
+            1
+        ],
+        "gas_per_code_byte": [
+            1280,
+            1
+        ]
+    },
     "os_resources": {
         "execute_syscalls": {
             "DelegateCall": {

--- a/crates/cairo-profiler/tests/data/missing_syscall_versioned_constants.json
+++ b/crates/cairo-profiler/tests/data/missing_syscall_versioned_constants.json
@@ -1,4 +1,18 @@
 {
+    "archival_data_gas_costs": {
+        "gas_per_data_felt": [
+            5120,
+            1
+        ],
+        "event_key_factor": [
+            2,
+            1
+        ],
+        "gas_per_code_byte": [
+            1280,
+            1
+        ]
+    },
     "os_constants": {
         "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
         "default_entry_point_selector": 0,

--- a/crates/cairo-profiler/tests/data/test_versioned_constants.json
+++ b/crates/cairo-profiler/tests/data/test_versioned_constants.json
@@ -1,4 +1,18 @@
 {
+    "archival_data_gas_costs": {
+        "gas_per_data_felt": [
+            5120,
+            1
+        ],
+        "event_key_factor": [
+            2,
+            1
+        ],
+        "gas_per_code_byte": [
+            1280,
+            1
+        ]
+    },
     "os_constants": {
         "constructor_entry_point_selector": "0x28ffe4ff0f226a9107253e17a904099aa4f63a02a5621de0576e5aa71bc5194",
         "default_entry_point_selector": 0,


### PR DESCRIPTION
Related to https://github.com/software-mansion/cairo-profiler/issues/166

## Introduced changes

This PR is a part of a bigger stack with an end goal to allow l2 gas profiling.
The idea is that each "top entrypoint" (ie each top level nested call of snforge test execution entrypoint) is treated as a separate transaction.

Each such transaction brings transaction calldata cost and signature cost (if eligible).
Each function called inside such transaction has its own l2 gas estimation (including syscalls). 
EmitEvent syscalls also include keys and data emitted by thich syscall.
as per https://docs.starknet.io/architecture/fees/#l2_data

The PRs are:
-- Include archival data gas costs in versioned constants (This PR)
-- Add l2 gas sample - execution resources on function level ()
-- Add tests for l2 sample ()
-- Include starknet resources in l2 sample ()
-- Update docs ()

## Checklist

- [X] Linked relevant issue
- [ ] Updated relevant documentation (README.md)
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
