### PR TITLE
Improve error message, when unable to map Syscall to SyscallSelector

### DIFF
--- a/crates/cairo-profiler/src/trace_reader/function_trace_builder/stack_trace.rs
+++ b/crates/cairo-profiler/src/trace_reader/function_trace_builder/stack_trace.rs
@@ -102,7 +102,14 @@ pub fn map_syscall_trace_to_sample(
             &function_name
                 .0
                 .parse::<DeprecatedSyscallSelector>()
-                .expect("Failed to map function to SyscallSelector"),
+                .expect(
+                    "Failed to map function to SyscallSelector.\n\n\
+                          This usually means that a syscall was encountered that the current cairo-profiler \
+                          version does not yet recognise. \n\
+                          Try updating cairo-profiler to the latest version, and if the issue persists, \
+                          consider opening a bug report: https://github.com/software-mansion/cairo-profiler/issues/new",
+                )
+            ,
         )
         .unwrap();
 


### PR DESCRIPTION
Closes #214

When a new syscall is being introduced and people use it, but also use an older profiler that does not know about this sycall yet, they see "Failed to map function to SyscallSelector: VariantNotFound", which is not very helpful. This change aims to point the users what might have went wrong, and what are possible actions.

(encountered in profiler 0.10 and meta_tx_v0 that was introduced in 0.11)

## Introduced changes

- Improve error message with a cause and a possible fix, when the profiler is unable to map syscall to the syscall selector

## Checklist

- [X] Linked relevant issue
- [ ] Updated relevant documentation (README.md)
- [ ] Added relevant tests
- [X] Performed self-review of the code
- [ ] Added changes to `CHANGELOG.md`
